### PR TITLE
Fix .webp display in cookbook notebooks

### DIFF
--- a/cookbook/recipes/capabilities/captioning/captioning.ipynb
+++ b/cookbook/recipes/capabilities/captioning/captioning.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(IPyImage(filename=str(SUBURBAN_STREET)))\n",
+    "display(IPyImage(url=f\"{ASSET_BASE}/capabilities/caption/suburban_street.webp\"))\n",
     "street_caption = caption(str(SUBURBAN_STREET), style=\"concise\", expects=\"text\")\n",
     "print(street_caption.text)"
    ]

--- a/cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb
+++ b/cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "from pydantic import BaseModel, Field\nfrom typing import Literal\n\n\nclass SceneAnalysis(BaseModel):\n    \"\"\"Structured scene analysis output.\"\"\"\n\n    scene_type: str = Field(description=\"Category: outdoor, indoor, urban, nature\")\n    main_subjects: list[str] = Field(description=\"Primary objects in the scene\")\n    mood: Literal[\"calm\", \"energetic\", \"dramatic\", \"peaceful\", \"tense\"]\n    time_of_day: Literal[\"morning\", \"afternoon\", \"evening\", \"night\", \"unknown\"]\n\n\n@perceive(model=\"isaac-0.2-1b\", response_format=pydantic_format(SceneAnalysis))\ndef analyze_scene(img_path):\n    return image(img_path) + text(\"Analyze this scene. Output in JSON with scene type, subjects, mood and time of day.\")\n\n\ndisplay(IPyImage(filename=str(SCENE_PATH), width=400))\nresult = analyze_scene(str(SCENE_PATH))\n\n# Parse directly into the Pydantic model\nanalysis = SceneAnalysis.model_validate_json(result.text)\nprint(f\"Scene type: {analysis.scene_type}\")\nprint(f\"Subjects: {analysis.main_subjects}\")\nprint(f\"Mood: {analysis.mood}\")\nprint(f\"Time: {analysis.time_of_day}\")",
+   "source": "from pydantic import BaseModel, Field\nfrom typing import Literal\n\n\nclass SceneAnalysis(BaseModel):\n    \"\"\"Structured scene analysis output.\"\"\"\n\n    scene_type: str = Field(description=\"Category: outdoor, indoor, urban, nature\")\n    main_subjects: list[str] = Field(description=\"Primary objects in the scene\")\n    mood: Literal[\"calm\", \"energetic\", \"dramatic\", \"peaceful\", \"tense\"]\n    time_of_day: Literal[\"morning\", \"afternoon\", \"evening\", \"night\", \"unknown\"]\n\n\n@perceive(model=\"isaac-0.2-1b\", response_format=pydantic_format(SceneAnalysis))\ndef analyze_scene(img_path):\n    return image(img_path) + text(\"Analyze this scene. Output in JSON with scene type, subjects, mood and time of day.\")\n\n\ndisplay(IPyImage(url=IMAGE_URL, width=400))\nresult = analyze_scene(str(SCENE_PATH))\n\n# Parse directly into the Pydantic model\nanalysis = SceneAnalysis.model_validate_json(result.text)\nprint(f\"Scene type: {analysis.scene_type}\")\nprint(f\"Subjects: {analysis.main_subjects}\")\nprint(f\"Mood: {analysis.mood}\")\nprint(f\"Time: {analysis.time_of_day}\")",
    "outputs": [],
    "execution_count": null
   },
@@ -68,7 +68,7 @@
   {
    "cell_type": "code",
    "metadata": {},
-   "source": "@perceive(model=\"isaac-0.2-1b\", response_format=regex_format(\"(calm|energetic|dramatic|peaceful|tense)\"))\ndef classify_mood(img_path):\n    return image(img_path) + text(\"Analyze this scene and output its mood.\")\n\n\ndisplay(IPyImage(filename=str(SCENE_PATH), width=400))\nresult = classify_mood(str(SCENE_PATH))\n\nprint(f\"Mood: {result.text}\")",
+   "source": "@perceive(model=\"isaac-0.2-1b\", response_format=regex_format(\"(calm|energetic|dramatic|peaceful|tense)\"))\ndef classify_mood(img_path):\n    return image(img_path) + text(\"Analyze this scene and output its mood.\")\n\n\ndisplay(IPyImage(url=IMAGE_URL, width=400))\nresult = classify_mood(str(SCENE_PATH))\n\nprint(f\"Mood: {result.text}\")",
    "outputs": [],
    "execution_count": null
   }

--- a/cookbook/recipes/capabilities/ocr/ocr.ipynb
+++ b/cookbook/recipes/capabilities/ocr/ocr.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display(IPyImage(filename=str(LABELS)))\n",
+    "display(IPyImage(url=IMAGE_URL))\n",
     "ocr_result = ocr(str(LABELS), prompt=OCR_PROMPT)\n",
     "print(ocr_result.text)\n",
     "lines = [line.strip() for line in ocr_result.text.split(\"\\n\") if line.strip()]\n",


### PR DESCRIPTION
## Summary

Three cookbook notebooks were crashing on the cell that previews the source image:

```
ValueError: Cannot embed the 'webp' image format
```

`IPython.display.Image(filename=...)` defaults to `embed=True`, which only accepts `png/jpg/jpeg/gif`. Switching to `IPyImage(url=...)` emits a plain `<img>` tag that the browser handles — webp is supported in every modern browser, so no asset conversion is needed.

## Affected notebooks

- `cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb` (cells 8 + 10)
- `cookbook/recipes/capabilities/ocr/ocr.ipynb` (cell 10)
- `cookbook/recipes/capabilities/captioning/captioning.ipynb` (cell 10)

The 3 other notebooks that download `.webp` but display the annotated `.png` output (`visual-qa`, `object-detection`, `in-context-learning`) are unaffected and untouched.

## Test plan

- [x] Each notebook still parses as valid JSON (11 / 12 / 15 cells respectively)
- [x] Open each in Colab, confirm the source-image cell renders without the ValueError

## Out of scope

The cell-1 `pip install --upgrade perceptron pydantic` in `constrained-decoding.ipynb` causes a noisy gradio/pydantic compatibility warning. That fix is in a separate PR.