### PR TITLE
Drop pydantic upgrade in constrained-decoding pip install

### DIFF
--- a/cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb
+++ b/cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --upgrade perceptron pydantic --quiet\n"
+    "%pip install --upgrade perceptron --quiet\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary

The first cell of `constrained-decoding.ipynb` runs:

```
%pip install --upgrade perceptron pydantic --quiet
```

In Google Colab this triggers a noisy red ERROR-looking message:

```
ERROR: pip's dependency resolver does not currently take into account all the packages...
gradio 5.50.0 requires pydantic<=2.12.3,>=2.0, but you have pydantic 2.13.3 which is incompatible.
```

Why: Colab's base image pre-installs gradio 5.50.0 (which pins `pydantic <= 2.12.3`), and the upgrade pushes pydantic past that pin. Gradio isn't imported by any cookbook notebook, so the "incompatibility" is purely cosmetic — but it looks broken to new users running the Structured Outputs notebook for the first time.

## Fix

Drop `pydantic` from the install. `perceptron`'s `pyproject.toml` only requires `pydantic >= 2.0`, which Colab's base already satisfies. All other cookbook notebooks already use `--upgrade perceptron --quiet` without the pydantic upgrade — this brings `constrained-decoding` in line.

## Test plan

- [x] Open the notebook in Colab; confirm cell 1 no longer prints the gradio warning
- [x] Confirm `pydantic_format` (used in cell 8) still works with whatever pydantic version Colab ships

## Out of scope

The webp display crash (`ValueError: Cannot embed the 'webp' image format`) in the same notebook is fixed in PR #53.