### PR TITLE
Support video and change contracts to media_obj

### DIFF
--- a/cookbook/recipes/capabilities/captioning/captioning.ipynb
+++ b/cookbook/recipes/capabilities/captioning/captioning.ipynb
@@ -62,7 +62,7 @@
    "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
-   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw, ImageFont\n\nfrom perceptron import caption, configure\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nSUBURBAN_STREET = \"suburban_street.webp\"\nSOLAR_ARRAY = \"solar_array.webp\"\nSOLAR_ANNOTATED = Path(\"solar_array_annotated.png\")"
+   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw, ImageFont\n\nfrom perceptron import caption, configure, image\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nSUBURBAN_STREET = \"suburban_street.webp\"\nSOLAR_ARRAY = \"solar_array.webp\"\nSOLAR_ANNOTATED = Path(\"solar_array_annotated.png\")"
   },
   {
    "cell_type": "markdown",
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "display(IPyImage(url=f\"{ASSET_BASE}/capabilities/caption/suburban_street.webp\"))\n",
-    "street_caption = caption(str(SUBURBAN_STREET), style=\"concise\", expects=\"text\")\n",
+    "street_caption = caption(image(str(SUBURBAN_STREET)), style=\"concise\", expects=\"text\")\n",
     "print(street_caption.text)"
    ]
   },
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "solar_caption = caption(\n",
-    "    str(SOLAR_ARRAY),\n",
+    "    image(str(SOLAR_ARRAY)),\n",
     "    style=\"detailed\",\n",
     "    expects=\"box\",\n",
     ")\n",

--- a/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb
+++ b/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb
@@ -73,7 +73,7 @@
    "id": "bf5dd34b",
    "metadata": {},
    "outputs": [],
-   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw, ImageFont\n\nfrom perceptron import annotate_image, bbox, configure, detect\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nEXAMPLE_IMAGE = \"cake_mixer_example.webp\"\nTARGET_IMAGE = \"find_kitchen_item.webp\"\nANNOTATED_PATH = Path(\"find_kitchen_item_annotated.png\")"
+   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw, ImageFont\n\nfrom perceptron import annotate_image, bbox, configure, detect, image\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nEXAMPLE_IMAGE = \"cake_mixer_example.webp\"\nTARGET_IMAGE = \"find_kitchen_item.webp\"\nANNOTATED_PATH = Path(\"find_kitchen_item_annotated.png\")"
   },
   {
    "cell_type": "markdown",
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "bootstrap = detect(\n",
-    "    str(EXAMPLE_IMAGE),\n",
+    "    image(str(EXAMPLE_IMAGE)),\n",
     "    classes=[\"objectCategory1\"],\n",
     "    max_outputs=1,\n",
     ")\n",
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "result = detect(\n",
-    "    str(TARGET_IMAGE),\n",
+    "    image(str(TARGET_IMAGE)),\n",
     "    classes=[\"objectCategory1\"],\n",
     "    examples=[example_shot],\n",
     ")\n",

--- a/cookbook/recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb
+++ b/cookbook/recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb
@@ -63,7 +63,7 @@
    "id": "8dd0d8092fe74a7c96281538738b07e2",
    "metadata": {},
    "outputs": [],
-   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw, ImageFont\n\nfrom perceptron import annotate_image, bbox, configure, detect\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nCAT_IMAGE = \"classA.jpg\"\nDOG_IMAGE = \"classB.webp\"\nTARGET_IMAGE = Path(\"cat_dog_input.png\")"
+   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw, ImageFont\n\nfrom perceptron import annotate_image, bbox, configure, detect, image\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nCAT_IMAGE = \"classA.jpg\"\nDOG_IMAGE = \"classB.webp\"\nTARGET_IMAGE = Path(\"cat_dog_input.png\")"
   },
   {
    "cell_type": "markdown",
@@ -115,7 +115,7 @@
    "outputs": [],
    "source": [
     "result = detect(\n",
-    "    str(TARGET_IMAGE),\n",
+    "    image(str(TARGET_IMAGE)),\n",
     "    classes=[\"classA\", \"classB\"],\n",
     "    examples=[cat_example, dog_example],\n",
     ")\n",

--- a/cookbook/recipes/capabilities/ocr/ocr.ipynb
+++ b/cookbook/recipes/capabilities/ocr/ocr.ipynb
@@ -62,7 +62,7 @@
    "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
-   "source": "import os\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\n\nfrom perceptron import configure, ocr\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nLABELS = \"grocery_labels.webp\"\nOCR_PROMPT = \"Extract each produce label along with its listed price.\""
+   "source": "import os\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\n\nfrom perceptron import configure, image, ocr\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nLABELS = \"grocery_labels.webp\"\nOCR_PROMPT = \"Extract each produce label along with its listed price.\""
   },
   {
    "cell_type": "markdown",
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "display(IPyImage(url=IMAGE_URL))\n",
-    "ocr_result = ocr(str(LABELS), prompt=OCR_PROMPT)\n",
+    "ocr_result = ocr(image(str(LABELS)), prompt=OCR_PROMPT)\n",
     "print(ocr_result.text)"
    ]
   },

--- a/cookbook/recipes/capabilities/visual-qa/visual-qa.ipynb
+++ b/cookbook/recipes/capabilities/visual-qa/visual-qa.ipynb
@@ -73,7 +73,7 @@
    "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "outputs": [],
-   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw\n\nfrom perceptron import configure, question\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nSCENE_PATH = \"studio_scene.webp\"\nANNOTATED_PATH = Path(\"studio_scene_annotated.png\")"
+   "source": "import os\nfrom pathlib import Path\n\nfrom IPython.display import Image as IPyImage\nfrom IPython.display import display\nfrom PIL import Image, ImageDraw\n\nfrom perceptron import configure, image, question\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.1\",\n    api_key=api_key,\n)\n\nSCENE_PATH = \"studio_scene.webp\"\nANNOTATED_PATH = Path(\"studio_scene_annotated.png\")"
   },
   {
    "cell_type": "markdown",
@@ -92,7 +92,7 @@
    "outputs": [],
    "source": [
     "QUESTION = \"What is the focal point of this scene? Be concise\"\n",
-    "qa_result = question(str(SCENE_PATH), QUESTION, expects=\"box\")\n",
+    "qa_result = question(image(str(SCENE_PATH)), QUESTION, expects=\"box\")\n",
     "print(qa_result.text)\n",
     "boxes = qa_result.points or []\n",
     "print(f\"Returned {len(boxes)} supporting regions\")"

--- a/src/perceptron/__init__.py
+++ b/src/perceptron/__init__.py
@@ -28,7 +28,7 @@ from .client import (
     regex_format,
 )
 from .config import config, configure, settings
-from .dsl.nodes import agent, block, box, image, point, polygon, system, text
+from .dsl.nodes import agent, block, box, image, point, polygon, system, text, video
 from .dsl.perceive import PerceiveResult, async_perceive, inspect_task, perceive
 from .errors import (
     AnchorError,
@@ -41,7 +41,7 @@ from .errors import (
     TimeoutError,
     TransportError,
 )
-from .highlevel import MediaInput, caption, detect, detect_from_coco, ocr, ocr_html, ocr_markdown, question
+from .highlevel import caption, detect, detect_from_coco, ocr, ocr_html, ocr_markdown, question
 from .pointing.geometry import scale_points_to_pixels
 from .pointing.parser import (
     PointParser,
@@ -83,7 +83,6 @@ __all__ = [
     "ExpectationError",
     "JsonSchemaFormat",
     "JsonSchemaSpec",
-    "MediaInput",
     "PerceiveResult",
     "PointParser",
     "Polygon",
@@ -130,4 +129,5 @@ __all__ = [
     "system",
     "tensorstream",
     "text",
+    "video",
 ]

--- a/src/perceptron/client.py
+++ b/src/perceptron/client.py
@@ -266,6 +266,15 @@ def _response_json(resp) -> dict[str, Any]:
     return resp.json()
 
 
+def _is_url_payload(item: dict[str, Any]) -> bool:
+    """True when the payload should pass through as a URL rather than a data URL."""
+
+    if item.get("url"):
+        return True
+    payload = item.get("content")
+    return isinstance(payload, str) and payload.startswith(("http://", "https://"))
+
+
 def _task_to_openai_messages(task: dict) -> list[dict[str, Any]]:
     messages: list[dict[str, Any]] = []
     current_role: str | None = None
@@ -299,7 +308,7 @@ def _task_to_openai_messages(task: dict) -> list[dict[str, Any]]:
             payload = item.get("content")
             if payload is None:
                 continue
-            if isinstance(payload, str) and payload.startswith(("http://", "https://")):
+            if _is_url_payload(item):
                 image_part = {"type": "image_url", "image_url": {"url": payload}}
             else:
                 fmt = item.get("format")
@@ -318,6 +327,29 @@ def _task_to_openai_messages(task: dict) -> list[dict[str, Any]]:
                 _flush()
             current_role = role
             current_content.append(image_part)
+            contains_non_text = True
+        elif itype == "video":
+            payload = item.get("content")
+            if payload is None:
+                continue
+            if _is_url_payload(item):
+                video_part = {"type": "video_url", "video_url": {"url": payload}}
+            else:
+                fmt = item.get("format")
+                if fmt is None:
+                    raise BadRequestError(
+                        "Could not determine video format from input. The wire protocol "
+                        "supports mp4 and webm.",
+                        code="invalid_video_format",
+                    )
+                video_part = {
+                    "type": "video_url",
+                    "video_url": {"url": f"data:video/{fmt};base64,{payload}"},
+                }
+            if current_role not in {role, None}:
+                _flush()
+            current_role = role
+            current_content.append(video_part)
             contains_non_text = True
         else:
             continue

--- a/src/perceptron/dsl/nodes.py
+++ b/src/perceptron/dsl/nodes.py
@@ -43,6 +43,16 @@ class Image(DSLNode):
 
 
 @dataclass
+class Video(DSLNode):
+    """Video content. Accepts path/str (URL or file)/bytes; format auto-detected from magic bytes."""
+
+    obj: Any
+
+
+Media = Image | Video
+
+
+@dataclass
 class PointTag(DSLNode):
     x: int
     y: int
@@ -112,6 +122,16 @@ def agent(content: str) -> Agent:
 def image(obj: Any) -> Image:
     """Create an image node from path/bytes/PIL.Image/np.ndarray."""
     return Image(obj)
+
+
+def video(obj: Any) -> Video:
+    """Create a video node from path/str (URL or file)/bytes.
+
+    Format is auto-detected from magic bytes (mp4 / webm) for bytes and path
+    input; HTTP(S) URLs are passed through and the server infers from the
+    response.
+    """
+    return Video(obj)
 
 
 def point(

--- a/src/perceptron/dsl/perceive.py
+++ b/src/perceptron/dsl/perceive.py
@@ -64,6 +64,9 @@ from .nodes import (
 from .nodes import (
     PolygonTag as PolygonTagNode,
 )
+from .nodes import (
+    Video as VideoNode,
+)
 
 _IMAGE_SIGNATURES = (
     b"\x89PNG\r\n\x1a\n",
@@ -132,20 +135,21 @@ def _to_b64_image(obj: Any) -> tuple[str, dict]:
     Accepts: Path/str (path or http/https URL), bytes, file-like, PIL.Image.Image, numpy.ndarray (HxWxC, uint8)
     """
     meta: dict[str, Any] = {}
+
+    if isinstance(obj, str) and urlparse(obj).scheme in {"http", "https"}:
+        return obj, {}
+
     if isinstance(obj, (str, Path)):
-        if isinstance(obj, str):
-            parsed = urlparse(obj)
-            if parsed.scheme in {"http", "https"}:
-                return obj, {}
         p = Path(obj)
-        with open(p, "rb") as f:
-            data = f.read()
+        data = p.read_bytes()
         meta = _validate_image_bytes(data, origin=str(p))
         b64 = base64.b64encode(data).decode("ascii")
         return b64, meta
+
     if isinstance(obj, bytes):
         b64, meta = _encode_bytes(obj)
         return b64, meta
+
     if PILImage is not None and isinstance(obj, PILImage.Image):  # type: ignore[attr-defined]
         meta["width"], meta["height"] = obj.size
         buf = BytesIO()
@@ -153,6 +157,7 @@ def _to_b64_image(obj: Any) -> tuple[str, dict]:
         meta["format"] = "png"
         b64 = base64.b64encode(buf.getvalue()).decode("ascii")
         return b64, meta
+
     if np is not None and isinstance(obj, np.ndarray):  # type: ignore[arg-type]
         h, w = obj.shape[:2]
         meta["width"], meta["height"] = int(w), int(h)
@@ -164,7 +169,62 @@ def _to_b64_image(obj: Any) -> tuple[str, dict]:
         meta["format"] = "png"
         b64 = base64.b64encode(buf.getvalue()).decode("ascii")
         return b64, meta
+
     raise TypeError(f"Unsupported image object: {type(obj)}")
+
+
+def _detect_video_format(data: bytes) -> str | None:
+    """Wire-protocol video format from magic bytes (mp4/webm only)."""
+
+    # mp4 / quicktime: bytes [4:8] == b"ftyp"
+    if len(data) >= 8 and data[4:8] == b"ftyp":
+        return "mp4"
+    # webm / matroska: EBML header
+    if data.startswith(b"\x1a\x45\xdf\xa3"):
+        return "webm"
+    return None
+
+
+def _to_b64_video(obj: Any) -> tuple[str, dict[str, Any]]:
+    """Return (base64-or-URL, metadata).
+
+    Accepts: Path/str (path or http/https URL) or bytes. URLs are returned
+    verbatim with ``meta["url"]=True``; bytes are base64-encoded and the
+    format is detected from magic bytes (mp4 / webm).
+    """
+
+    meta: dict[str, Any] = {}
+
+    if isinstance(obj, str) and urlparse(obj).scheme in {"http", "https"}:
+        meta["url"] = True
+        return obj, meta
+
+    if isinstance(obj, (str, Path)):
+        p = Path(obj)
+        data = p.read_bytes()
+        fmt = _detect_video_format(data)
+        if fmt is None:
+            raise BadRequestError(
+                "Video format could not be detected. The wire protocol supports mp4 and webm.",
+                code="invalid_video",
+                details={"origin": str(p)},
+            )
+        meta["format"] = fmt
+        b64 = base64.b64encode(data).decode("ascii")
+        return b64, meta
+
+    if isinstance(obj, bytes):
+        fmt = _detect_video_format(obj)
+        if fmt is None:
+            raise BadRequestError(
+                "Video format could not be detected from bytes. The wire protocol supports mp4 and webm.",
+                code="invalid_video",
+            )
+        meta["format"] = fmt
+        b64 = base64.b64encode(obj).decode("ascii")
+        return b64, meta
+
+    raise TypeError(f"Unsupported video object: {type(obj)}")
 
 
 def _compile(nodes: DSLNode | Sequence, *, expects: str | None, strict: bool) -> tuple[dict, list[dict]]:
@@ -214,6 +274,17 @@ def _compile(nodes: DSLNode | Sequence, *, expects: str | None, strict: bool) ->
                         "width": meta.get("width"),
                         "height": meta.get("height"),
                     },
+                }
+            )
+        elif isinstance(node, VideoNode):
+            payload, meta = _to_b64_video(node.obj)
+            content.append(
+                {
+                    "type": "video",
+                    "role": "user",
+                    "content": payload,
+                    "format": meta.get("format"),
+                    "url": bool(meta.get("url")),
                 }
             )
         elif isinstance(node, (PointTagNode, BoxTagNode, PolygonTagNode)):

--- a/src/perceptron/highlevel.py
+++ b/src/perceptron/highlevel.py
@@ -5,19 +5,17 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Union
-
-if TYPE_CHECKING:
-    import numpy as np
-    from PIL import Image as PILImage
-
-#: Anything the high-level helpers accept as image / video media input.
-#: Resolved by ``perceptron.dsl.perceive._to_b64_image`` at runtime.
-MediaInput = Union[str, Path, bytes, "PILImage.Image", "np.ndarray"]
+from typing import Any
 
 from .annotations import annotate_image, canonicalize_text_collections, serialize_annotations
 from .client import _PROVIDER_CONFIG, ResponseFormat, _select_model
 from .config import settings
+from .dsl.nodes import (
+    Image as ImageNode,
+)
+from .dsl.nodes import (
+    Media as MediaNode,
+)
 from .dsl.nodes import (
     Sequence as SequenceNode,
 )
@@ -139,7 +137,7 @@ def _run_perceive_sequence(
 
 
 def _caption_sequence(
-    media: MediaInput,
+    media_node: MediaNode,
     style: str,
     expects: str | None,
     template: CaptionPromptTemplate,
@@ -150,13 +148,13 @@ def _caption_sequence(
     nodes = []
     if template.system_instruction:
         nodes.append(system(template.system_instruction))
-    nodes.append(image_node(media))
+    nodes.append(media_node)
     nodes.append(text(style_map[style]))
     return SequenceNode(nodes)
 
 
 def caption(
-    media: MediaInput,
+    media_obj: MediaNode,
     *,
     style: str = "concise",
     expects: str = "box",
@@ -165,6 +163,9 @@ def caption(
     **gen_kwargs: Any,
 ):
     """Generate a caption for media using predefined best-practice prompts.
+
+    ``media_obj`` must be wrapped with :func:`perceptron.image` or
+    :func:`perceptron.video`.
 
     Args:
         response_format: Optional constraint for output format. Use
@@ -183,7 +184,7 @@ def caption(
     }
 
     return _run_perceive_sequence(
-        builder=lambda: _caption_sequence(media, style, structured_expectation, caption_template),
+        builder=lambda: _caption_sequence(media_obj, style, structured_expectation, caption_template),
         perceive_base_kwargs=base_kwargs,
         gen_kwargs=gen_kwargs,
         response_format=response_format,
@@ -196,7 +197,7 @@ def caption(
 
 
 def _question_sequence(
-    media: MediaInput,
+    media_node: MediaNode,
     question_text: str,
     expects: str | None,
     template: QuestionPromptTemplate,
@@ -209,13 +210,13 @@ def _question_sequence(
     nodes: list = []
     if system_instruction:
         nodes.append(system(system_instruction))
-    nodes.append(image_node(media))
+    nodes.append(media_node)
     nodes.append(text(question_text))
     return SequenceNode(nodes)
 
 
 def question(
-    media: MediaInput,
+    media_obj: MediaNode,
     question_text: str,
     *,
     expects: str = "text",
@@ -224,6 +225,9 @@ def question(
     **gen_kwargs: Any,
 ):
     """Answer a question about media, optionally requesting structured outputs.
+
+    ``media_obj`` must be wrapped with :func:`perceptron.image` or
+    :func:`perceptron.video`.
 
     Args:
         response_format: Optional constraint for output format. Use
@@ -242,7 +246,7 @@ def question(
     }
 
     return _run_perceive_sequence(
-        builder=lambda: _question_sequence(media, question_text, structured_expectation, question_template),
+        builder=lambda: _question_sequence(media_obj, question_text, structured_expectation, question_template),
         perceive_base_kwargs=base_kwargs,
         gen_kwargs=gen_kwargs,
         response_format=response_format,
@@ -255,21 +259,21 @@ def question(
 
 
 def _ocr_sequence(
-    image: MediaInput,
+    image_node_obj: ImageNode,
     prompt: str | None,
     template: OcrPromptTemplate,
 ) -> SequenceNode:
     nodes = []
     if template.system_instruction:
         nodes.append(system(template.system_instruction))
-    nodes.append(image_node(image))
+    nodes.append(image_node_obj)
     if prompt:
         nodes.append(text(prompt))
     return SequenceNode(nodes)
 
 
 def _run_ocr(
-    image: MediaInput,
+    image_node_obj: ImageNode,
     *,
     prompt: str | None,
     stream: bool,
@@ -296,7 +300,7 @@ def _run_ocr(
     }
 
     return _run_perceive_sequence(
-        builder=lambda: _ocr_sequence(image, effective_prompt, ocr_template),
+        builder=lambda: _ocr_sequence(image_node_obj, effective_prompt, ocr_template),
         perceive_base_kwargs=base_kwargs,
         gen_kwargs=gen_kwargs,
         response_format=response_format,
@@ -304,7 +308,7 @@ def _run_ocr(
 
 
 def ocr(
-    image: MediaInput,
+    image_obj: ImageNode,
     *,
     prompt: str | None = None,
     stream: bool = False,
@@ -313,6 +317,8 @@ def ocr(
 ):
     """Perform OCR on an image (plain text).
 
+    ``image_obj`` must be wrapped with :func:`perceptron.image`.
+
     Args:
         response_format: Optional constraint for output format. Use
             :func:`~perceptron.json_schema_format` or :func:`~perceptron.regex_format`
@@ -320,7 +326,7 @@ def ocr(
     """
 
     return _run_ocr(
-        image,
+        image_obj,
         prompt=prompt,
         stream=stream,
         mode="plain",
@@ -330,7 +336,7 @@ def ocr(
 
 
 def ocr_markdown(
-    image: MediaInput,
+    image_obj: ImageNode,
     *,
     prompt: str | None = None,
     stream: bool = False,
@@ -339,6 +345,8 @@ def ocr_markdown(
 ):
     """Perform OCR and request Markdown output when supported by the provider.
 
+    ``image_obj`` must be wrapped with :func:`perceptron.image`.
+
     Args:
         response_format: Optional constraint for output format. Use
             :func:`~perceptron.json_schema_format` or :func:`~perceptron.regex_format`
@@ -346,7 +354,7 @@ def ocr_markdown(
     """
 
     return _run_ocr(
-        image,
+        image_obj,
         prompt=prompt,
         stream=stream,
         mode="markdown",
@@ -356,7 +364,7 @@ def ocr_markdown(
 
 
 def ocr_html(
-    image: MediaInput,
+    image_obj: ImageNode,
     *,
     prompt: str | None = None,
     stream: bool = False,
@@ -365,6 +373,8 @@ def ocr_html(
 ):
     """Perform OCR and request HTML output when supported by the provider.
 
+    ``image_obj`` must be wrapped with :func:`perceptron.image`.
+
     Args:
         response_format: Optional constraint for output format. Use
             :func:`~perceptron.json_schema_format` or :func:`~perceptron.regex_format`
@@ -372,7 +382,7 @@ def ocr_html(
     """
 
     return _run_ocr(
-        image,
+        image_obj,
         prompt=prompt,
         stream=stream,
         mode="html",
@@ -399,7 +409,7 @@ def _detect_system_message(
 
 
 def _detect_sequence(
-    media: MediaInput,
+    media_node: MediaNode,
     *,
     classes: Sequence[str] | None,
     examples: Sequence[Any] | None,
@@ -412,13 +422,12 @@ def _detect_sequence(
         if ex.prompt:
             sequence = sequence + text(ex.prompt)
         sequence = sequence + agent(ex.tags)
-    im = image_node(media)
-    sequence = sequence + im
+    sequence = sequence + media_node
     return sequence
 
 
 def detect(  # noqa: PLR0913
-    media: MediaInput,
+    media_obj: MediaNode,
     *,
     classes: Sequence[str] | None = None,
     examples: Sequence[Any] | None = None,
@@ -429,6 +438,9 @@ def detect(  # noqa: PLR0913
     **gen_kwargs: Any,
 ):
     """High-level object detection helper.
+
+    ``media_obj`` must be wrapped with :func:`perceptron.image` or
+    :func:`perceptron.video`.
 
     Args:
         response_format: Optional constraint for output format. Use
@@ -448,7 +460,7 @@ def detect(  # noqa: PLR0913
         base_kwargs["strict"] = strict
 
     return _run_perceive_sequence(
-        builder=lambda: _detect_sequence(media, classes=classes, examples=examples, template=detect_template),
+        builder=lambda: _detect_sequence(media_obj, classes=classes, examples=examples, template=detect_template),
         perceive_base_kwargs=base_kwargs,
         gen_kwargs=gen_kwargs,
         response_format=response_format,
@@ -719,7 +731,7 @@ def detect_from_coco(  # noqa: PLR0913
 
         image_bytes = image_path.read_bytes()
         result = detect(
-            image_bytes,
+            image_node(image_bytes),
             classes=class_list,
             stream=False,
             examples=examples if examples else None,

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -51,8 +51,8 @@ def test_docs_capabilities_captioning_example():
     img_path = _doc_asset("suburban_street.webp")
 
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
-        text_only = caption(img_path, style="concise", expects="text")
-        boxes = caption(img_path, style="detailed", expects="box")
+        text_only = caption(image(img_path), style="concise", expects="text")
+        boxes = caption(image(img_path), style="detailed", expects="box")
 
     assert isinstance(text_only.text, str)
     assert text_only.text.strip() != ""
@@ -134,7 +134,7 @@ def test_docs_capabilities_object_detection_example():
 
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
         result = detect(
-            frame_path,
+            image(frame_path),
             classes=["helmet", "vest"],
             expects="box",
         )
@@ -156,7 +156,7 @@ def test_docs_capabilities_ocr_example():
     img_path = _doc_asset("grocery_labels.webp")
 
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
-        result = ocr(img_path, prompt="Extract product name and price", stream=False)
+        result = ocr(image(img_path), prompt="Extract product name and price", stream=False)
 
     assert isinstance(result.text, str)
     assert "price" in result.text.lower()
@@ -170,7 +170,7 @@ def test_docs_capabilities_visual_qa_example():
 
     question_text = "What stands out in this studio scene?"
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
-        result = question(frame_path, question_text, expects="box")
+        result = question(image(frame_path), question_text, expects="box")
 
     assert isinstance(result.text, str)
     assert result.text.strip() != ""
@@ -213,7 +213,7 @@ def test_docs_in_context_single_example():
 
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
         bootstrap = detect(
-            exemplar_path,
+            image(exemplar_path),
             classes=["objectCategory1"],
         )
 
@@ -235,7 +235,7 @@ def test_docs_in_context_single_example():
         )
 
         result = detect(
-            target_path,
+            image(target_path),
             classes=["objectCategory1"],
             examples=[example_shot],
         )
@@ -263,7 +263,7 @@ def test_docs_in_context_multi_example():
 
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
         result = detect(
-            target_path,
+            image(target_path),
             classes=["classA", "classB"],
             examples=[cat_example, dog_example],
         )
@@ -292,7 +292,7 @@ def test_docs_error_invalid_image_decision_tree(tmp_path):
     bad_path.write_text("not an image", encoding="utf-8")
 
     with pytest.raises(BadRequestError) as excinfo:
-        caption(str(bad_path), expects="text")
+        caption(image(str(bad_path)), expects="text")
 
     err = excinfo.value
     assert err.code == "invalid_image"
@@ -383,7 +383,7 @@ def test_docs_batch_async_example():
     async def detect_async(image_path, *, classes):
         return await asyncio.to_thread(
             detect,
-            image_path,
+            image(image_path),
             classes=classes,
             expects="box",
         )
@@ -408,6 +408,6 @@ def test_docs_scaling_low_latency_example():
     cfg.update({"timeout": 8, "max_tokens": 256})
 
     with config(**cfg):
-        result = detect(sample_image, classes=["scratch"], expects="box")
+        result = detect(image(sample_image), classes=["scratch"], expects="box")
 
     assert isinstance(result.points, list) or result.points is None

--- a/tests/test_highlevel_caption_ocr.py
+++ b/tests/test_highlevel_caption_ocr.py
@@ -1,6 +1,6 @@
 from _image_fixtures import PNG_BYTES
 
-from perceptron import caption, json_schema_format, ocr
+from perceptron import caption, image, json_schema_format, ocr
 from perceptron import client as client_mod
 from perceptron import config as cfg
 
@@ -12,7 +12,7 @@ def _echo_task(self, task, **kwargs):  # pylint: disable=unused-argument
 def test_caption_highlevel_compile_only(monkeypatch):
     monkeypatch.setattr(client_mod.Client, "generate", _echo_task)
     with cfg(api_key="test-key", provider="fal"):
-        res = caption(PNG_BYTES, style="concise")
+        res = caption(image(PNG_BYTES), style="concise")
     assert res.raw and isinstance(res.raw, dict)
     assert res.raw.get("expects") == "box"
     content = res.raw.get("content", [])
@@ -23,7 +23,7 @@ def test_caption_highlevel_compile_only(monkeypatch):
 def test_caption_highlevel_text_expectation(monkeypatch):
     monkeypatch.setattr(client_mod.Client, "generate", _echo_task)
     with cfg(api_key="test-key", provider="fal"):
-        res = caption(PNG_BYTES, expects="text")
+        res = caption(image(PNG_BYTES), expects="text")
     assert res.raw and isinstance(res.raw, dict)
     assert res.raw.get("expects") is None
     content = res.raw.get("content", [])
@@ -35,7 +35,7 @@ def test_caption_hints_skipped_for_qwen(monkeypatch):
     """Qwen model has skip_structured_hints=True, so no hints should be present."""
     monkeypatch.setattr(client_mod.Client, "generate", _echo_task)
     with cfg(api_key="test-key", provider="perceptron", model="qwen3-vl-235b-a22b-thinking"):
-        res = caption(PNG_BYTES, style="concise")
+        res = caption(image(PNG_BYTES), style="concise")
     assert res.raw and isinstance(res.raw, dict)
     content = res.raw.get("content", [])
     assert all("<hint>" not in (entry.get("content") or "") for entry in content)
@@ -44,7 +44,7 @@ def test_caption_hints_skipped_for_qwen(monkeypatch):
 
 def test_caption_style_validation():
     try:
-        caption(PNG_BYTES, style="unknown")
+        caption(image(PNG_BYTES), style="unknown")
     except Exception as exc:
         assert "unsupported" in str(exc).lower()
     else:
@@ -54,7 +54,7 @@ def test_caption_style_validation():
 def test_ocr_boxes_compile_only(monkeypatch):
     monkeypatch.setattr(client_mod.Client, "generate", _echo_task)
     with cfg(api_key="test-key", provider="fal"):
-        res = ocr(PNG_BYTES)
+        res = ocr(image(PNG_BYTES))
     assert res.raw and isinstance(res.raw, dict)
     assert res.raw.get("expects") is None
     assert res.errors == []
@@ -63,7 +63,7 @@ def test_ocr_boxes_compile_only(monkeypatch):
 def test_ocr_plain_text_compile_only(monkeypatch):
     monkeypatch.setattr(client_mod.Client, "generate", _echo_task)
     with cfg(api_key="test-key", provider="fal"):
-        res = ocr(PNG_BYTES)
+        res = ocr(image(PNG_BYTES))
     assert res.raw and isinstance(res.raw, dict)
     assert res.raw.get("expects") is None
     assert res.errors == []
@@ -94,7 +94,7 @@ def test_caption_response_format_propagates(monkeypatch):
 
     schema = {"type": "object", "properties": {"description": {"type": "string"}}}
     with cfg(api_key="test-key", provider="fal", base_url="https://mock.api"):
-        caption(PNG_BYTES, style="concise", response_format=json_schema_format(schema))
+        caption(image(PNG_BYTES), style="concise", response_format=json_schema_format(schema))
 
     assert "payload" in captured
     payload = captured["payload"]

--- a/tests/test_highlevel_detect.py
+++ b/tests/test_highlevel_detect.py
@@ -3,7 +3,7 @@ import json
 from _image_fixtures import PNG_BYTES
 
 from cookbook.utils import cookbook_asset
-from perceptron import annotate_image, detect, detect_from_coco
+from perceptron import annotate_image, detect, detect_from_coco, image
 from perceptron import client as client_mod
 from perceptron import config as cfg
 from perceptron.highlevel import CocoDetectResult
@@ -35,7 +35,7 @@ def test_detect_compile_only(monkeypatch):
 
     # Execute with stubbed client to inspect compiled task without API calls
     with cfg(api_key="test-key", provider="fal"):
-        res = detect(PNG_BYTES, classes=["person"], max_tokens=16)
+        res = detect(image(PNG_BYTES), classes=["person"], max_tokens=16)
     assert res.raw and isinstance(res.raw, dict)
     roles = [item.get("role") for item in res.raw.get("content", [])]
     assert roles and roles[0] == "system"
@@ -51,7 +51,7 @@ def test_detect_with_examples(monkeypatch):
     )
     # Execute with stubbed client to inspect compiled task without API calls
     with cfg(api_key="test-key", provider="fal"):
-        res = detect(PNG_BYTES, classes=["car"], examples=[example])
+        res = detect(image(PNG_BYTES), classes=["car"], examples=[example])
     content = res.raw.get("content", [])
     # Should include example turns before target image
     assistants = [item for item in content if item.get("role") == "assistant"]
@@ -76,7 +76,7 @@ def test_detect_with_collection_examples(monkeypatch):
 
     # Execute with stubbed client to inspect compiled task without API calls
     with cfg(api_key="test-key", provider="fal"):
-        res = detect(PNG_BYTES, classes=["group"], examples=[example])
+        res = detect(image(PNG_BYTES), classes=["group"], examples=[example])
     content = res.raw.get("content", [])
     assistants = [item for item in content if item.get("role") == "assistant"]
     assert assistants and "<collection" in assistants[0]["content"]
@@ -94,7 +94,7 @@ def test_detect_canonicalizes_collection_order(monkeypatch):
 
     # Execute with stubbed client to inspect compiled task without API calls
     with cfg(api_key="test-key", provider="fal"):
-        res = detect(b"target", classes=["person", "car"], examples=[example])
+        res = detect(image(b"target"), classes=["person", "car"], examples=[example])
 
     assistant = next(item for item in res.raw["content"] if item.get("role") == "assistant")
     content = assistant["content"]
@@ -118,7 +118,7 @@ def test_detect_sorts_collection_children(monkeypatch):
 
     # Execute with stubbed client to inspect compiled task without API calls
     with cfg(api_key="test-key", provider="fal"):
-        res = detect(b"target", classes=["group"], examples=[example])
+        res = detect(image(b"target"), classes=["group"], examples=[example])
 
     assistant = next(item for item in res.raw["content"] if item.get("role") == "assistant")
     content = assistant["content"]
@@ -169,7 +169,7 @@ def test_prompt_collection_canonicalization(monkeypatch):
 
     # Execute with stubbed client to inspect compiled task without API calls
     with cfg(api_key="test-key", provider="fal"):
-        res = detect(b"target", classes=["group"], examples=[example])
+        res = detect(image(b"target"), classes=["group"], examples=[example])
 
     prompt_text = next(
         item for item in res.raw["content"] if item.get("role") == "user" and "context" in item.get("content", "")
@@ -181,7 +181,7 @@ def test_detect_stream(monkeypatch):
     monkeypatch.setattr(client_mod.Client, "stream", _StubClient.stream)
 
     with cfg(api_key="test-key", provider="fal"):
-        events = list(detect(PNG_BYTES, classes=None, stream=True))
+        events = list(detect(image(PNG_BYTES), classes=None, stream=True))
     assert events[0]["type"] == "text.delta"
     assert events[-1]["type"] == "final"
 
@@ -219,7 +219,7 @@ def test_detect_flattens_collection_response(monkeypatch):
     monkeypatch.setattr(client_mod, "_http_client", lambda timeout: _Client())
 
     with cfg(provider="fal", base_url="https://unit.test", api_key="test-key"):
-        res = detect(PNG_BYTES, classes=["dog"])
+        res = detect(image(PNG_BYTES), classes=["dog"])
 
     assert res.text and "<collection" in res.text
     assert res.points and len(res.points) == 2
@@ -249,10 +249,10 @@ def test_detect_from_coco(monkeypatch, tmp_path):
             self.points = None
             self.raw = {"text": text}
 
-    def _fake_detect(image_bytes, *, classes, stream=False, examples=None, **kwargs):
+    def _fake_detect(image_obj, *, classes, stream=False, examples=None, **kwargs):
         assert classes == ["cell"]
         assert stream is False
-        assert image_bytes == b"image-one"
+        assert image_obj.obj == b"image-one"
         assert examples is None
         return _StubResult("detected")
 
@@ -302,7 +302,7 @@ def test_detect_from_coco_shots(monkeypatch, tmp_path):
             self.points = None
             self.raw = {"text": "detected"}
 
-    def _fake_detect(image_bytes, *, classes, stream=False, examples=None, **kwargs):
+    def _fake_detect(image_obj, *, classes, stream=False, examples=None, **kwargs):
         assert classes == ["cell", "artifact"]
         assert stream is False
         assert examples is not None
@@ -341,7 +341,7 @@ def test_examples_icl_detection_sequence(monkeypatch):
 
     with cfg(provider="perceptron", api_key="test-key"):
         res = detect(
-            str(cookbook_asset("in-context-learning", "multi", "cat_dog_input.png")),
+            image(str(cookbook_asset("in-context-learning", "multi", "cat_dog_input.png"))),
             classes=["classA", "classB"],
             examples=[cat_example, dog_example],
         )

--- a/tests/test_prompt_profiles.py
+++ b/tests/test_prompt_profiles.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import pytest
 
-from perceptron import caption, detect, ocr, ocr_html, ocr_markdown
+from perceptron import caption, detect, image, ocr, ocr_html, ocr_markdown
 from perceptron import client as client_mod
 from perceptron import config as cfg
 from perceptron.client import _PROVIDER_CONFIG, _select_model
@@ -32,7 +32,7 @@ def _collect_text(content, *, role: str) -> list[str]:
 
 def test_caption_uses_qwen_prompt_text():
     with cfg(api_key="test-key", provider="perceptron"):
-        res = caption(PNG_BYTES, style="concise", model="qwen3-vl-235b-a22b-thinking")
+        res = caption(image(PNG_BYTES), style="concise", model="qwen3-vl-235b-a22b-thinking")
 
     content = res.raw.get("content", [])
     system_messages = _collect_text(content, role="system")
@@ -46,7 +46,7 @@ def test_caption_uses_qwen_prompt_text():
 
 def test_caption_defaults_to_isaac_prompt_on_fal():
     with cfg(api_key="test-key", provider="fal"):
-        res = caption(PNG_BYTES, style="concise")
+        res = caption(image(PNG_BYTES), style="concise")
 
     content = res.raw.get("content", [])
     system_messages = _collect_text(content, role="system")
@@ -82,7 +82,7 @@ def test_detect_qwen_prompt_reports_json_bbox():
         "person",
     ]
     with cfg(api_key="test-key", provider="perceptron"):
-        res = detect(PNG_BYTES, classes=categories, model="qwen3-vl-235b-a22b-thinking")
+        res = detect(image(PNG_BYTES), classes=categories, model="qwen3-vl-235b-a22b-thinking")
 
     content = res.raw.get("content", [])
     system_messages = _collect_text(content, role="system")
@@ -97,7 +97,7 @@ def test_detect_qwen_prompt_reports_json_bbox():
 def test_config_context_propagates_default_model():
     categories = ["plate/dish"]
     with cfg(api_key="test-key", provider="perceptron", model="qwen3-vl-235b-a22b-thinking"):
-        res = detect(PNG_BYTES, classes=categories)
+        res = detect(image(PNG_BYTES), classes=categories)
 
     content = res.raw.get("content", [])
     system_messages = _collect_text(content, role="system")
@@ -113,7 +113,7 @@ def test_env_default_model_applies(monkeypatch):
 
     categories = ["plate/dish"]
     with cfg(api_key="test-key", provider="perceptron"):
-        res = detect(PNG_BYTES, classes=categories)
+        res = detect(image(PNG_BYTES), classes=categories)
 
     content = res.raw.get("content", [])
     system_messages = _collect_text(content, role="system")
@@ -127,12 +127,12 @@ def test_env_default_model_applies(monkeypatch):
 def test_incompatible_default_model_raises():
     categories = ["plate/dish"]
     with pytest.raises(BadRequestError), cfg(api_key="test-key", provider="fal", model="qwen3-vl-235b-a22b-thinking"):
-        detect(PNG_BYTES, classes=categories)
+        detect(image(PNG_BYTES), classes=categories)
 
 
 def test_isaac_markdown_ocr_prompt():
     with cfg(api_key="test-key", provider="fal"):
-        res = ocr_markdown(PNG_BYTES)
+        res = ocr_markdown(image(PNG_BYTES))
 
     content = res.raw.get("content", [])
     user_messages = _collect_text(content, role="user")
@@ -141,7 +141,7 @@ def test_isaac_markdown_ocr_prompt():
 
 def test_qwen_plain_ocr_prompt():
     with cfg(api_key="test-key", provider="perceptron"):
-        res = ocr(PNG_BYTES, model="qwen3-vl-235b-a22b-thinking")
+        res = ocr(image(PNG_BYTES), model="qwen3-vl-235b-a22b-thinking")
 
     content = res.raw.get("content", [])
     user_messages = _collect_text(content, role="user")
@@ -150,7 +150,7 @@ def test_qwen_plain_ocr_prompt():
 
 def test_qwen_markdown_ocr_prompt():
     with cfg(api_key="test-key", provider="perceptron"):
-        res = ocr_markdown(PNG_BYTES, model="qwen3-vl-235b-a22b-thinking")
+        res = ocr_markdown(image(PNG_BYTES), model="qwen3-vl-235b-a22b-thinking")
 
     content = res.raw.get("content", [])
     user_messages = _collect_text(content, role="user")
@@ -159,7 +159,7 @@ def test_qwen_markdown_ocr_prompt():
 
 def test_qwen_html_ocr_prompt():
     with cfg(api_key="test-key", provider="perceptron"):
-        res = ocr_html(PNG_BYTES, model="qwen3-vl-235b-a22b-thinking")
+        res = ocr_html(image(PNG_BYTES), model="qwen3-vl-235b-a22b-thinking")
 
     content = res.raw.get("content", [])
     user_messages = _collect_text(content, role="user")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,132 @@
+"""Video support: DSL node, wire format, highlevel routing, OCR rejection."""
+
+from __future__ import annotations
+
+import pytest
+from _image_fixtures import PNG_BYTES
+
+from perceptron import caption, ocr, question, video
+from perceptron import client as client_mod
+from perceptron import config as cfg
+from perceptron.client import _task_to_openai_messages
+from perceptron.dsl.nodes import Video as VideoNode
+from perceptron.dsl.perceive import _compile, _detect_video_format
+from perceptron.errors import BadRequestError
+
+# Minimal mp4 / webm magic-byte fixtures. These are byte-stub level (not full
+# decodable streams) — enough to exercise format sniffing and the wire path.
+MP4_BYTES = b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42" + b"\x00" * 16
+WEBM_BYTES = b"\x1a\x45\xdf\xa3" + b"\x00" * 32
+
+
+@pytest.fixture(autouse=True)
+def _stub_generate(monkeypatch):
+    def _echo(self, task, **kwargs):  # pylint: disable=unused-argument
+        return {"text": "", "points": None, "parsed": None, "raw": task}
+
+    monkeypatch.setattr(client_mod.Client, "generate", _echo)
+
+
+# ---- Format detection -----------------------------------------------------
+
+
+def test_detect_video_format_mp4():
+    assert _detect_video_format(MP4_BYTES) == "mp4"
+
+
+def test_detect_video_format_webm():
+    assert _detect_video_format(WEBM_BYTES) == "webm"
+
+
+def test_detect_video_format_unknown_returns_none():
+    assert _detect_video_format(b"not a video") is None
+
+
+# ---- DSL node -------------------------------------------------------------
+
+
+def test_video_factory_returns_video_node():
+    assert isinstance(video("https://example.com/v.mp4"), VideoNode)
+
+
+def test_video_url_compiles_with_passthrough():
+    seq = video("https://example.com/v.mp4")
+    task, issues = _compile(seq, expects=None, strict=False)
+    assert issues == []
+    parts = [p for p in task["content"] if p.get("type") == "video"]
+    assert len(parts) == 1
+    assert parts[0]["url"] is True
+    assert parts[0]["content"] == "https://example.com/v.mp4"
+
+
+def test_video_bytes_detect_mp4_format():
+    seq = video(MP4_BYTES)
+    task, _ = _compile(seq, expects=None, strict=False)
+    parts = [p for p in task["content"] if p.get("type") == "video"]
+    assert parts[0]["format"] == "mp4"
+
+
+def test_video_bytes_detect_webm_format():
+    seq = video(WEBM_BYTES)
+    task, _ = _compile(seq, expects=None, strict=False)
+    parts = [p for p in task["content"] if p.get("type") == "video"]
+    assert parts[0]["format"] == "webm"
+
+
+def test_unsniffable_video_bytes_raise():
+    with pytest.raises(BadRequestError) as excinfo:
+        seq = video(b"not a video")
+        _compile(seq, expects=None, strict=False)
+    assert excinfo.value.code == "invalid_video"
+
+
+# ---- Wire format ----------------------------------------------------------
+
+
+def test_wire_video_url_emits_video_url_part():
+    seq = video("https://example.com/v.mp4")
+    task, _ = _compile(seq, expects=None, strict=False)
+    msgs = _task_to_openai_messages(task)
+    part = msgs[0]["content"][0]
+    assert part["type"] == "video_url"
+    assert part["video_url"]["url"] == "https://example.com/v.mp4"
+
+
+def test_wire_video_base64_emits_data_url():
+    seq = video(MP4_BYTES)
+    task, _ = _compile(seq, expects=None, strict=False)
+    msgs = _task_to_openai_messages(task)
+    part = msgs[0]["content"][0]
+    assert part["type"] == "video_url"
+    assert part["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+
+# ---- High-level routing ---------------------------------------------------
+
+
+def test_caption_accepts_video():
+    with cfg(api_key="test", provider="fal"):
+        res = caption(video("https://x.com/v.mp4"))
+    parts = [p for p in res.raw["content"] if p.get("type") == "video"]
+    assert len(parts) == 1
+
+
+def test_question_accepts_video():
+    with cfg(api_key="test", provider="fal"):
+        res = question(video("https://x.com/v.mp4"), "what happens?")
+    parts = [p for p in res.raw["content"] if p.get("type") == "video"]
+    assert len(parts) == 1
+
+
+def test_caption_requires_wrapped_input():
+    """Loose input is rejected — caller must wrap with image() or video()."""
+
+    with pytest.raises(TypeError):
+        with cfg(api_key="test", provider="fal"):
+            caption(PNG_BYTES)
+
+
+def test_ocr_requires_wrapped_input():
+    with pytest.raises(TypeError):
+        with cfg(api_key="test", provider="fal"):
+            ocr(PNG_BYTES)

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from _image_fixtures import PNG_BYTES
 
-from perceptron import caption, ocr, question, video
+from perceptron import caption, detect, ocr, question, video
 from perceptron import client as client_mod
 from perceptron import config as cfg
 from perceptron.client import _task_to_openai_messages
@@ -73,6 +73,20 @@ def test_video_bytes_detect_webm_format():
     assert parts[0]["format"] == "webm"
 
 
+def test_video_file_path_reads_and_encodes(tmp_path):
+    """File-path branch of _to_b64_video: read from disk, sniff format, base64."""
+
+    clip = tmp_path / "clip.mp4"
+    clip.write_bytes(MP4_BYTES)
+
+    seq = video(str(clip))
+    task, _ = _compile(seq, expects=None, strict=False)
+    parts = [p for p in task["content"] if p.get("type") == "video"]
+    assert len(parts) == 1
+    assert parts[0]["format"] == "mp4"
+    assert parts[0]["url"] is False
+
+
 def test_unsniffable_video_bytes_raise():
     with pytest.raises(BadRequestError) as excinfo:
         seq = video(b"not a video")
@@ -114,6 +128,13 @@ def test_caption_accepts_video():
 def test_question_accepts_video():
     with cfg(api_key="test", provider="fal"):
         res = question(video("https://x.com/v.mp4"), "what happens?")
+    parts = [p for p in res.raw["content"] if p.get("type") == "video"]
+    assert len(parts) == 1
+
+
+def test_detect_accepts_video():
+    with cfg(api_key="test", provider="fal"):
+        res = detect(video("https://x.com/v.mp4"), classes=["person"])
     parts = [p for p in res.raw["content"] if p.get("type") == "video"]
     assert len(parts) == 1
 


### PR DESCRIPTION
## Summary

  Adds video support to the Python SDK and tightens the high-level helper contracts to require explicit `image()` / `video()` wrapping at the call boundary — matching `perceptron-rs`'s `Image` / `Video` / `Media` tagged unions.

  ## What's new

  **Video DSL node**
  - New `Video` dataclass and `video()` factory (`src/perceptron/dsl/nodes.py`).
  - `video()` accepts URL strings, file paths, or raw bytes. Format (mp4 / webm) is detected from magic bytes; unsniffable bytes raise `BadRequestError("invalid_video")`.
  - New `Media = Image | Video` alias for use in helper signatures.

  **Compile + wire format**
  - `_compile` handles `VideoNode` and emits a `{"type": "video", ...}` content part (`src/perceptron/dsl/perceive.py`).
  - `_task_to_openai_messages` emits OpenAI-compat `video_url` parts — either a passthrough URL or a `data:video/{mp4|webm};base64,...` data URL (`src/perceptron/client.py`).
  - Shared `_is_url_payload` helper covers both image and video URL detection.

  **High-level helpers accept video**
  - `caption`, `question`, `detect` accept `MediaNode` (image or video).
  - `ocr` / `ocr_markdown` / `ocr_html` remain image-only via type annotation (`ImageNode`).

  **Strict contract change (breaking)**
  - High-level helpers no longer accept loose input (bytes, paths, PIL.Image, ndarray). Callers must wrap with `image(...)` or `video(...)`.
  - Removes ~25 lines of coercion logic and the URL-vs-bytes-vs-path ambiguity that becomes acute once video bytes enter the picture.
  - Loose input now raises `TypeError` from the compile pipeline.
  - Param renames on the helpers: `image_obj` → `media_obj` for caption/question/detect; `image` → `image_obj` for ocr helpers.

  ## Migration

  ```python
  # Before
  caption(b"...png bytes...", style="concise")
  detect("path/to/frame.jpg", classes=["person"])
  ocr(pil_image)

  # After
  caption(image(b"...png bytes..."), style="concise")
  detect(image("path/to/frame.jpg"), classes=["person"])
  ocr(image(pil_image))

  # New: video
  caption(video("https://example.com/clip.mp4"))
  detect(video(open("clip.webm", "rb").read()), classes=["person"])
  ```