### PR TITLE
Split the prompts between video and image

### DIFF
--- a/src/perceptron/highlevel.py
+++ b/src/perceptron/highlevel.py
@@ -139,7 +139,6 @@ def _run_perceive_sequence(
 def _caption_sequence(
     media_node: MediaNode,
     style: str,
-    expects: str | None,
     template: CaptionPromptTemplate,
 ) -> SequenceNode:
     style_map = template.style_prompts
@@ -149,7 +148,7 @@ def _caption_sequence(
     if template.system_instruction:
         nodes.append(system(template.system_instruction))
     nodes.append(media_node)
-    nodes.append(text(style_map[style]))
+    nodes.append(text(style_map[style].get(media_node)))
     return SequenceNode(nodes)
 
 
@@ -184,7 +183,7 @@ def caption(
     }
 
     return _run_perceive_sequence(
-        builder=lambda: _caption_sequence(media_obj, style, structured_expectation, caption_template),
+        builder=lambda: _caption_sequence(media_obj, style, caption_template),
         perceive_base_kwargs=base_kwargs,
         gen_kwargs=gen_kwargs,
         response_format=response_format,
@@ -399,12 +398,13 @@ def ocr_html(
 def _detect_system_message(
     classes: Sequence[str] | None,
     template: DetectPromptTemplate,
+    media: MediaNode,
 ) -> SequenceNode:
     if classes:
         categories = ", ".join(str(c) for c in classes)
-        message = template.category_instruction_template.format(categories=categories)
+        message = template.category_instruction_template.get(media).format(categories=categories)
     else:
-        message = template.general_instruction
+        message = template.general_instruction.get(media)
     return SequenceNode([system(message)])
 
 
@@ -415,7 +415,7 @@ def _detect_sequence(
     examples: Sequence[Any] | None,
     template: DetectPromptTemplate,
 ) -> SequenceNode:
-    sequence = _detect_system_message(classes, template)
+    sequence = _detect_system_message(classes, template, media_node)
     normalized_examples = _normalize_examples(examples, classes) if examples else []
     for ex in normalized_examples:
         sequence = sequence + image_node(ex.image)

--- a/src/perceptron/prompting.py
+++ b/src/perceptron/prompting.py
@@ -11,10 +11,27 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 
+from .dsl.nodes import Image, Media, Video
+
+
+@dataclass(frozen=True)
+class ModalityPrompt:
+    """Prompt text that varies by media modality (image vs video)."""
+
+    image: str
+    video: str
+
+    def get(self, media: Media) -> str:
+        if isinstance(media, Image):
+            return self.image
+        if isinstance(media, Video):
+            return self.video
+        raise TypeError(f"ModalityPrompt.get expected Image or Video, got {type(media).__name__}")
+
 
 @dataclass(frozen=True)
 class CaptionPromptTemplate:
-    style_prompts: dict[str, str]
+    style_prompts: dict[str, ModalityPrompt]
     system_instruction: str | None = None
 
 
@@ -33,8 +50,8 @@ class OcrPromptTemplate:
 
 @dataclass(frozen=True)
 class DetectPromptTemplate:
-    general_instruction: str
-    category_instruction_template: str
+    general_instruction: ModalityPrompt
+    category_instruction_template: ModalityPrompt
 
 
 @dataclass(frozen=True)
@@ -117,8 +134,14 @@ _ISAAC_PROFILE = HighLevelPromptProfile(
     key="isaac-default",
     caption=CaptionPromptTemplate(
         style_prompts={
-            "concise": "Provide a concise, human-friendly caption for the upcoming image.",
-            "detailed": "Provide a detailed caption describing key objects, relationships, and context in the upcoming image.",
+            "concise": ModalityPrompt(
+                image="Provide a concise, human-friendly caption for the upcoming image.",
+                video="Provide a concise, human-friendly caption for the upcoming video.",
+            ),
+            "detailed": ModalityPrompt(
+                image="Provide a detailed caption describing key objects, relationships, and context in the upcoming image.",
+                video="Provide a detailed caption describing key objects, relationships, and context in the upcoming video.",
+            ),
         },
     ),
     question=QuestionPromptTemplate(
@@ -137,8 +160,14 @@ _ISAAC_PROFILE = HighLevelPromptProfile(
         default_mode="plain",
     ),
     detect=DetectPromptTemplate(
-        general_instruction="Your goal is to segment out the objects in the scene",
-        category_instruction_template="Your goal is to segment out the following categories: {categories}",
+        general_instruction=ModalityPrompt(
+            image="Your goal is to segment out the objects in the scene",
+            video="Your goal is to segment out the objects in the scene. Make sure to track the objects.",
+        ),
+        category_instruction_template=ModalityPrompt(
+            image="Your goal is to segment out the following categories: {categories}",
+            video="Your goal is to segment out the following categories: {categories}. Make sure to track the objects.",
+        ),
     ),
 )
 
@@ -147,9 +176,13 @@ _QWEN_PROFILE = HighLevelPromptProfile(
     caption=CaptionPromptTemplate(
         system_instruction=None,
         style_prompts={
-            "concise": "Describe the primary subjects, their actions, and visible context in one vivid sentence.",
-            "detailed": (
-                "Provide a multi-sentence caption that calls out subjects, relationships, scene intent, and any text embedded in the image."
+            "concise": ModalityPrompt(
+                image="Describe the primary subjects, their actions, and visible context in one vivid sentence.",
+                video="Describe the primary subjects, their actions, and visible context in one vivid sentence.",
+            ),
+            "detailed": ModalityPrompt(
+                image="Provide a multi-sentence caption that calls out subjects, relationships, scene intent, and any text embedded in the image.",
+                video="Provide a multi-sentence caption that calls out subjects, relationships, scene intent, and any text embedded in the video.",
             ),
         },
     ),
@@ -169,10 +202,13 @@ _QWEN_PROFILE = HighLevelPromptProfile(
         default_mode="plain",
     ),
     detect=DetectPromptTemplate(
-        general_instruction="Locate every object of interest and report bounding box coordinates in JSON format.",
-        category_instruction_template=(
-            'Locate every instance that belongs to the following categories: "{categories}". '
-            "Report bbox coordinates in JSON format."
+        general_instruction=ModalityPrompt(
+            image="Locate every object of interest and report bounding box coordinates in JSON format.",
+            video="Locate every object of interest and report bounding box coordinates in JSON format.",
+        ),
+        category_instruction_template=ModalityPrompt(
+            image='Locate every instance that belongs to the following categories: "{categories}". Report bbox coordinates in JSON format.',
+            video='Locate every instance that belongs to the following categories: "{categories}". Report bbox coordinates in JSON format.',
         ),
     ),
 )
@@ -198,6 +234,7 @@ __all__ = [
     "CaptionPromptTemplate",
     "DetectPromptTemplate",
     "HighLevelPromptProfile",
+    "ModalityPrompt",
     "OcrPromptTemplate",
     "PromptProfileRegistry",
     "QuestionPromptTemplate",

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 from _image_fixtures import PNG_BYTES
 
-from perceptron import caption, detect, ocr, question, video
+from perceptron import caption, detect, image, ocr, question, video
 from perceptron import client as client_mod
 from perceptron import config as cfg
 from perceptron.client import _task_to_openai_messages
@@ -137,6 +137,54 @@ def test_detect_accepts_video():
         res = detect(video("https://x.com/v.mp4"), classes=["person"])
     parts = [p for p in res.raw["content"] if p.get("type") == "video"]
     assert len(parts) == 1
+
+
+def test_caption_video_uses_video_modality_prompt():
+    """Isaac caption.concise should emit the video-modality wording for video input."""
+
+    with cfg(api_key="test", provider="fal"):
+        res = caption(video("https://x.com/v.mp4"), style="concise")
+    user_msgs = [
+        e["content"]
+        for e in res.raw["content"]
+        if e.get("type") == "text" and e.get("role") == "user"
+    ]
+    assert any("upcoming video" in m for m in user_msgs)
+
+
+def test_caption_image_uses_image_modality_prompt():
+    with cfg(api_key="test", provider="fal"):
+        res = caption(image(PNG_BYTES), style="concise")
+    user_msgs = [
+        e["content"]
+        for e in res.raw["content"]
+        if e.get("type") == "text" and e.get("role") == "user"
+    ]
+    assert any("upcoming image" in m for m in user_msgs)
+
+
+def test_detect_video_includes_tracking_instruction():
+    """Isaac detect appends a tracking hint when the media is video."""
+
+    with cfg(api_key="test", provider="fal"):
+        res = detect(video("https://x.com/v.mp4"), classes=["person"])
+    sys_msgs = [
+        e["content"]
+        for e in res.raw["content"]
+        if e.get("type") == "text" and e.get("role") == "system"
+    ]
+    assert any("Make sure to track the objects." in m for m in sys_msgs)
+
+
+def test_detect_image_omits_tracking_instruction():
+    with cfg(api_key="test", provider="fal"):
+        res = detect(image(PNG_BYTES), classes=["person"])
+    sys_msgs = [
+        e["content"]
+        for e in res.raw["content"]
+        if e.get("type") == "text" and e.get("role") == "system"
+    ]
+    assert all("Make sure to track" not in m for m in sys_msgs)
 
 
 def test_caption_requires_wrapped_input():


### PR DESCRIPTION
## Summary

  Adds modality-aware prompts so caption and detect produce wording tuned to image vs video input. New `ModalityPrompt` dataclass holds the image/video pair and resolves via type-dispatch on the `Media` node