### PR TITLE
Separate points, boxes, polygons in the payload

### DIFF
--- a/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb
+++ b/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb
@@ -134,7 +134,7 @@
     "    )\n",
     "\n",
     "result = detect_boxes(str(IMAGE_PATH))\n",
-    "print(f\"Detected {len(result.points or [])} boxes.\")"
+    "print(f\"Detected {len(result.boxes or [])} boxes.\")"
    ]
   },
   {
@@ -160,7 +160,7 @@
     "def to_px(point):\n",
     "    return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
     "\n",
-    "for idx, box in enumerate(result.points or []):\n",
+    "for idx, box in enumerate(result.boxes or []):\n",
     "    top_left = to_px(box.top_left)\n",
     "    bottom_right = to_px(box.bottom_right)\n",
     "    draw.rectangle([top_left, bottom_right], outline=\"lime\", width=3)\n",
@@ -168,7 +168,7 @@
     "    text_origin = (top_left[0], max(top_left[1] - 14, 0))\n",
     "    draw.text(text_origin, label, fill=\"lime\")\n",
     "\n",
-    "if not (result.points or []):\n",
+    "if not (result.boxes or []):\n",
     "    print(\"No boxes detected. Adjust the prompt or try another frame.\")\n",
     "\n",
     "img.save(ANNOTATED_PATH)\n",

--- a/cookbook/quickstart/quickstart_qwen/quickstart_qwen.ipynb
+++ b/cookbook/quickstart/quickstart_qwen/quickstart_qwen.ipynb
@@ -153,7 +153,7 @@
     "    )\n",
     "\n",
     "result = detect_flowers(str(IMAGE_PATH))\n",
-    "print(f\"Detected {len(result.points or [])} flowers.\")"
+    "print(f\"Detected {len(result.boxes or [])} flowers.\")"
    ]
   },
   {
@@ -179,7 +179,7 @@
     "def to_px(point):\n",
     "    return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
     "\n",
-    "for idx, box in enumerate(result.points or []):\n",
+    "for idx, box in enumerate(result.boxes or []):\n",
     "    top_left = to_px(box.top_left)\n",
     "    bottom_right = to_px(box.bottom_right)\n",
     "    draw.rectangle([top_left, bottom_right], outline=\"magenta\", width=3)\n",
@@ -187,7 +187,7 @@
     "    text_origin = (top_left[0], max(top_left[1] - 14, 0))\n",
     "    draw.text(text_origin, label, fill=\"magenta\")\n",
     "\n",
-    "if not (result.points or []):\n",
+    "if not (result.boxes or []):\n",
     "    print(\"No flowers detected. Adjust the prompt or try another frame.\")\n",
     "\n",
     "\n",

--- a/cookbook/recipes/capabilities/captioning/captioning.ipynb
+++ b/cookbook/recipes/capabilities/captioning/captioning.ipynb
@@ -101,7 +101,7 @@
     "    expects=\"box\",\n",
     ")\n",
     "print(solar_caption.text)\n",
-    "boxes = solar_caption.points or []\n",
+    "boxes = solar_caption.boxes or []\n",
     "print(f\"Returned {len(boxes)} grounded snippets\")"
    ]
   },

--- a/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb
+++ b/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb
@@ -96,10 +96,10 @@
     "    classes=[\"objectCategory1\"],\n",
     "    max_outputs=1,\n",
     ")\n",
-    "if not bootstrap.points:\n",
+    "if not bootstrap.boxes:\n",
     "    raise RuntimeError(\"Detect returned no boxes for the exemplar. Adjust the label or image.\")\n",
     "\n",
-    "first_box = bootstrap.points[0]\n",
+    "first_box = bootstrap.boxes[0]\n",
     "example_shot = annotate_image(\n",
     "    str(EXAMPLE_IMAGE),\n",
     "    {\n",
@@ -149,7 +149,7 @@
     ")\n",
     "\n",
     "print(result.text)\n",
-    "boxes = result.points or []\n",
+    "boxes = result.boxes or []\n",
     "print(f\"Returned {len(boxes)} grounded regions\")"
    ]
   },

--- a/cookbook/recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb
+++ b/cookbook/recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb
@@ -121,7 +121,7 @@
     ")\n",
     "\n",
     "print(result.text)\n",
-    "boxes = result.points or []\n",
+    "boxes = result.boxes or []\n",
     "for box in boxes:\n",
     "    print(box)"
    ]

--- a/cookbook/recipes/capabilities/object-detection/object-detection.ipynb
+++ b/cookbook/recipes/capabilities/object-detection/object-detection.ipynb
@@ -106,7 +106,7 @@
    "source": [
     "detection = detect_ppe(str(SCENE_PATH))\n",
     "print(detection.text)\n",
-    "boxes = detection.points or []\n",
+    "boxes = detection.boxes or []\n",
     "print(f\"Returned {len(boxes)} boxes\")"
    ]
   },

--- a/cookbook/recipes/capabilities/visual-qa/visual-qa.ipynb
+++ b/cookbook/recipes/capabilities/visual-qa/visual-qa.ipynb
@@ -94,7 +94,7 @@
     "QUESTION = \"What is the focal point of this scene? Be concise\"\n",
     "qa_result = question(image(str(SCENE_PATH)), QUESTION, expects=\"box\")\n",
     "print(qa_result.text)\n",
-    "boxes = qa_result.points or []\n",
+    "boxes = qa_result.boxes or []\n",
     "print(f\"Returned {len(boxes)} supporting regions\")"
    ]
   },

--- a/cookbook/recipes/tutorials/isaac_frame_by_frame/isaac_frame_by_frame.ipynb
+++ b/cookbook/recipes/tutorials/isaac_frame_by_frame/isaac_frame_by_frame.ipynb
@@ -136,7 +136,7 @@
     "\n",
     "for frame_path in tqdm(FRAME_PATHS, desc=\"Detecting frames\"):\n",
     "    result = detect_surfers(str(frame_path))\n",
-    "    boxes = result.points or []\n",
+    "    boxes = result.boxes or []\n",
     "    all_detections.append(\n",
     "        {\n",
     "            \"frame\": frame_path.name,\n",

--- a/src/perceptron/cli.py
+++ b/src/perceptron/cli.py
@@ -432,7 +432,7 @@ def _stream_render(
     bucket_name = _BUCKET_BY_EXPECTS.get(expects)
 
     text_buffer: list[str] = []
-    points_buffer: list[Any] = []
+    annotations_buffer: list[Any] = []
     errors: list[dict[str, Any]] = []
     final_result: dict[str, Any] | None = None
     usage_info: dict[str, Any] | None = None
@@ -451,13 +451,13 @@ def _stream_render(
         if not text_content:
             text_render.stylize("dim")
         body.append(text_render)
-        if points_buffer:
+        if annotations_buffer:
             if show_points_table:
-                body.append(_build_points_table(points_buffer))
+                body.append(_build_points_table(annotations_buffer))
             else:
                 summary = Text()
-                for idx, point in enumerate(points_buffer, 1):
-                    kind, coords, mention = _describe_point(point)
+                for idx, annotation in enumerate(annotations_buffer, 1):
+                    kind, coords, mention = _describe_point(annotation)
                     line = f"{idx}. {kind}: {coords}"
                     if mention:
                         line += f" ({mention})"
@@ -516,7 +516,7 @@ def _stream_render(
             elif event_type == "points.delta":
                 pts = event.get("points") or []
                 if pts:
-                    points_buffer.extend(pts)
+                    annotations_buffer.extend(pts)
             elif event_type == "error":
                 message = str(event.get("message") or "unknown error")
                 errors.append({"code": "stream_error", "message": message})
@@ -528,7 +528,7 @@ def _stream_render(
                 if final_result.get("text") is not None:
                     text_buffer = [final_result.get("text") or ""]
                 if bucket_name and final_result.get(bucket_name) is not None:
-                    points_buffer = list(final_result.get(bucket_name) or [])
+                    annotations_buffer = list(final_result.get(bucket_name) or [])
                 final_errs = final_result.get("errors") or []
                 if final_errs:
                     errors.extend(final_errs)
@@ -548,13 +548,13 @@ def _stream_render(
             "raw": None,
         }
         if bucket_name:
-            final_result[bucket_name] = points_buffer or None
+            final_result[bucket_name] = annotations_buffer or None
     else:
         # ensure buffers win if final result lacked data
         if final_result.get("text") is None:
             final_result["text"] = "".join(text_buffer) or None
-        if bucket_name and not final_result.get(bucket_name) and points_buffer:
-            final_result[bucket_name] = points_buffer
+        if bucket_name and not final_result.get(bucket_name) and annotations_buffer:
+            final_result[bucket_name] = annotations_buffer
         merged_errors = list(errors) if errors else []
         final_errs = final_result.get("errors") or []
         if final_errs:

--- a/src/perceptron/cli.py
+++ b/src/perceptron/cli.py
@@ -122,10 +122,23 @@ def _serialize_annotation(annotation: Any) -> Any:
     return annotation
 
 
+_BUCKET_BY_EXPECTS = {"point": "points", "box": "boxes", "polygon": "polygons"}
+
+
 def _serialize_points(points: list[Any] | None) -> list[Any] | None:
     if not points:
         return None
     return [_serialize_annotation(point) for point in points]
+
+
+def _bucket_for_expects(result: Any, expects: str | None) -> tuple[str, list[Any]] | None:
+    """Return the (name, list) of the bucket matching ``expects``, if it has data."""
+
+    bucket_name = _BUCKET_BY_EXPECTS.get(expects)
+    if bucket_name is None:
+        return None
+    items = getattr(result, bucket_name)
+    return (bucket_name, items) if items else None
 
 
 def _serialize_parsed(
@@ -149,14 +162,15 @@ def _serialize_parsed(
     return serialized
 
 
-def _result_payload(result: Any, *, include_raw: bool) -> dict[str, Any]:
+def _result_payload(result: Any, *, include_raw: bool, expects: str | None = None) -> dict[str, Any]:
     payload: dict[str, Any] = {}
     text_value = getattr(result, "text", None)
     if text_value is not None:
         payload["text"] = text_value
-    points = _serialize_points(getattr(result, "points", None))
-    if points is not None:
-        payload["points"] = points
+    populated = _bucket_for_expects(result, expects)
+    if populated is not None:
+        bucket_name, items = populated
+        payload[bucket_name] = _serialize_points(items)
     parsed = getattr(result, "parsed", None)
     serialized_parsed = _serialize_parsed(parsed)
     if serialized_parsed is not None:
@@ -267,11 +281,12 @@ def _process_directory(
         console.print(Panel(table, title="Errors", border_style="red"))
 
 
-def _caption_payload(result: Any) -> Any:
+def _caption_payload(result: Any, *, expects: str | None = None) -> Any:
     text_value = getattr(result, "text", None) or ""
-    points = _serialize_points(getattr(result, "points", None))
-    if points:
-        return {"text": text_value, "points": points}
+    populated = _bucket_for_expects(result, expects)
+    if populated is not None:
+        bucket_name, items = populated
+        return {"text": text_value, bucket_name: _serialize_points(items)}
     return text_value
 
 
@@ -280,10 +295,12 @@ def _ocr_payload(result: Any) -> str:
 
 
 def _detect_payload(result: Any) -> dict[str, Any]:
+    # Detect always emits boxes.
     payload: dict[str, Any] = {"text": getattr(result, "text", None) or ""}
-    points = _serialize_points(getattr(result, "points", None))
-    if points is not None:
-        payload["points"] = points
+    populated = _bucket_for_expects(result, "box")
+    if populated is not None:
+        bucket_name, items = populated
+        payload[bucket_name] = _serialize_points(items)
     parsed = getattr(result, "parsed", None)
     if parsed:
         payload["parsed"] = parsed
@@ -352,6 +369,8 @@ def _coerce_result_dict(result: dict[str, Any]) -> dict[str, Any]:
     return {
         "text": result.get("text"),
         "points": result.get("points"),
+        "boxes": result.get("boxes"),
+        "polygons": result.get("polygons"),
         "parsed": result.get("parsed"),
         "usage": result.get("usage"),
         "errors": result.get("errors") or [],
@@ -406,8 +425,11 @@ def _stream_render(
     output_format: OutputFormat,
     show_raw: bool,
     show_points_table: bool,
+    expects: str | None = None,
 ) -> None:
     """Render streaming events inside a live-updating panel."""
+
+    bucket_name = _BUCKET_BY_EXPECTS.get(expects)
 
     text_buffer: list[str] = []
     points_buffer: list[Any] = []
@@ -505,8 +527,8 @@ def _stream_render(
                 end_ts = time.perf_counter()
                 if final_result.get("text") is not None:
                     text_buffer = [final_result.get("text") or ""]
-                if final_result.get("points") is not None:
-                    points_buffer = list(final_result.get("points") or [])
+                if bucket_name and final_result.get(bucket_name) is not None:
+                    points_buffer = list(final_result.get(bucket_name) or [])
                 final_errs = final_result.get("errors") or []
                 if final_errs:
                     errors.extend(final_errs)
@@ -520,18 +542,19 @@ def _stream_render(
     if final_result is None:
         final_result = {
             "text": "".join(text_buffer) or None,
-            "points": points_buffer or None,
             "parsed": None,
             "usage": usage_info,
             "errors": _dedupe_errors(errors),
             "raw": None,
         }
+        if bucket_name:
+            final_result[bucket_name] = points_buffer or None
     else:
         # ensure buffers win if final result lacked data
         if final_result.get("text") is None:
             final_result["text"] = "".join(text_buffer) or None
-        if not final_result.get("points") and points_buffer:
-            final_result["points"] = points_buffer
+        if bucket_name and not final_result.get(bucket_name) and points_buffer:
+            final_result[bucket_name] = points_buffer
         merged_errors = list(errors) if errors else []
         final_errs = final_result.get("errors") or []
         if final_errs:
@@ -544,7 +567,7 @@ def _stream_render(
     result_ns = SimpleNamespace(**coerced)
 
     if output_format is OutputFormat.JSON:
-        console.print_json(data=_result_payload(result_ns, include_raw=show_raw))
+        console.print_json(data=_result_payload(result_ns, include_raw=show_raw, expects=expects))
     else:
         if coerced["errors"]:
             _print_errors(coerced["errors"])
@@ -559,23 +582,26 @@ def _render_result(
     output_format: OutputFormat,
     show_raw: bool,
     show_points_table: bool = False,
+    expects: str | None = None,
 ):
     if output_format is OutputFormat.JSON:
-        payload = _result_payload(result, include_raw=show_raw)
+        payload = _result_payload(result, include_raw=show_raw, expects=expects)
         console.print_json(data=payload)
         return
 
-    points_serialized = _serialize_points(getattr(result, "points", None))
+    populated = _bucket_for_expects(result, expects)
     console.print(Panel(result.text or "<no text>", title=title, border_style="green"))
-    if show_points_table and getattr(result, "points", None):
+    if show_points_table and populated is not None:
+        _, items = populated
         table = Table(title="Detections", show_header=True, header_style="bold blue")
         table.add_column("Bounding Box")
         table.add_column("Mention")
-        for point in result.points or []:
+        for point in items:
             table.add_row(str(point), getattr(point, "mention", ""))
         console.print(table)
-    elif points_serialized:
-        console.print_json(data={"points": points_serialized})
+    elif populated is not None:
+        bucket_name, items = populated
+        console.print_json(data={bucket_name: _serialize_points(items)})
     _print_errors(getattr(result, "errors", []))
     if show_raw and getattr(result, "raw", None):
         console.print(result.raw)
@@ -637,7 +663,7 @@ def caption(
             stream=stream,
             show_raw=show_raw,
             runner=lambda data: caption_image(data, style=style, expects=expects.value),
-            payload_factory=_caption_payload,
+            payload_factory=lambda result: _caption_payload(result, expects=expects.value),
         )
         return
 
@@ -655,6 +681,7 @@ def caption(
             output_format=output_format,
             show_raw=show_raw,
             show_points_table=expects is ExpectationType.BOX,
+            expects=expects_value,
         )
         return
 
@@ -665,6 +692,7 @@ def caption(
         output_format=output_format,
         show_raw=show_raw,
         show_points_table=expects is ExpectationType.BOX,
+        expects=expects_value,
     )
 
 
@@ -742,6 +770,7 @@ def detect(
             output_format=output_format,
             show_raw=show_raw,
             show_points_table=True,
+            expects="box",
         )
         return
     res = detect_image(img, classes=class_list)
@@ -751,6 +780,7 @@ def detect(
         output_format=output_format,
         show_raw=show_raw,
         show_points_table=True,
+        expects="box",
     )
 
 
@@ -794,6 +824,7 @@ def question(
             output_format=output_format,
             show_raw=show_raw,
             show_points_table=expects is ExpectationType.BOX,
+            expects=expects_value,
         )
         return
 
@@ -809,6 +840,7 @@ def question(
         output_format=output_format,
         show_raw=show_raw,
         show_points_table=show_points and expects is ExpectationType.BOX,
+        expects=expects_value,
     )
 
 

--- a/src/perceptron/client.py
+++ b/src/perceptron/client.py
@@ -33,6 +33,9 @@ from .errors import (
 from .expectations import STRUCTURED_EXPECTATIONS
 from .pointing.parser import extract_points, parse_text
 
+# Maps each spatial `expects` value to the PerceiveResult bucket it populates.
+_BUCKET_BY_EXPECTS = {"point": "points", "box": "boxes", "polygon": "polygons"}
+
 # ---------------------------------------------------------------------------
 # Response format types for constrained decoding
 # ---------------------------------------------------------------------------
@@ -113,7 +116,7 @@ class _StreamProcessor:
     ) -> None:
         self._client_core = client_core
         self._expects = expects
-        self._parse_points = parse_points and expects in {"point", "box", "polygon"}
+        self._parse_points = parse_points and expects in _BUCKET_BY_EXPECTS
         self._max_buffer_bytes = max_buffer_bytes
         self._cumulative: str = ""
         self._reasoning: str = ""
@@ -174,9 +177,10 @@ class _StreamProcessor:
         result: dict[str, Any] = {"text": content, "reasoning": reasoning, "raw": None}
         expects = self._expects
         parsed_segments: list[dict[str, Any]] | None = None
-        if expects in {"point", "box", "polygon"} and self._parsing_enabled and isinstance(content, str):
+        if expects in _BUCKET_BY_EXPECTS and self._parsing_enabled and isinstance(content, str):
             parsed_segments = parse_text(content)
-            result["points"] = [seg["value"] for seg in parsed_segments if seg["kind"] == expects]
+            bucket = _BUCKET_BY_EXPECTS[expects]
+            result[bucket] = [seg["value"] for seg in parsed_segments if seg["kind"] == expects]
             result["parsed"] = parsed_segments
         issues: list[dict[str, Any]] = []
         if not self._parsing_enabled:
@@ -189,27 +193,23 @@ class _StreamProcessor:
         return {
             "type": "final",
             "result": {
-                "text": result.get("text"),
-                "reasoning": result.get("reasoning"),
-                "points": result.get("points"),
-                "parsed": result.get("parsed"),
+                **result,
                 "usage": self._usage_payload,
                 "errors": issues,
-                "raw": result.get("raw"),
             },
         }
 
     def _point_events(self) -> list[dict[str, Any]]:
         events: list[dict[str, Any]] = []
         expects = self._expects
-        if expects not in {"point", "box", "polygon"}:
+        if expects not in _BUCKET_BY_EXPECTS:
             return events
         try:
             segments = parse_text(self._cumulative)
         except Exception:
             return events
         for seg in segments:
-            if seg.get("kind") not in {"point", "box", "polygon"}:
+            if seg.get("kind") not in _BUCKET_BY_EXPECTS:
                 continue
             span_info = seg.get("span")
             if not isinstance(span_info, dict):
@@ -758,9 +758,9 @@ class _ClientCore:
         content = message.get("content")
 
         result: dict[str, Any] = {"text": content, "reasoning": reasoning_content, "raw": data}
-        if expects in {"point", "box", "polygon"} and isinstance(content, str):
-            kind = "point" if expects == "point" else ("box" if expects == "box" else "polygon")
-            result["points"] = extract_points(content, expected=kind)
+        if expects in _BUCKET_BY_EXPECTS and isinstance(content, str):
+            bucket = _BUCKET_BY_EXPECTS[expects]
+            result[bucket] = extract_points(content, expected=expects)
             result["parsed"] = parse_text(content)
         return result
 

--- a/src/perceptron/dsl/perceive.py
+++ b/src/perceptron/dsl/perceive.py
@@ -376,17 +376,29 @@ def _compile(nodes: DSLNode | Sequence, *, expects: str | None, strict: bool) ->
 @dataclass
 class PerceiveResult:
     text: str | None
-    points: list[Any] | None
+    points: list[SinglePoint] | None
+    boxes: list[BoundingBox] | None
+    polygons: list[Polygon] | None
     parsed: list[dict] | None
     reasoning: str | None
     usage: dict | None
     errors: list[dict]
     raw: Any
 
-    def points_to_pixels(self, width: int, height: int, *, clamp: bool = True) -> list[Any] | None:
+    def points_to_pixels(self, width: int, height: int, *, clamp: bool = True) -> list[SinglePoint] | None:
         """Return a pixel-space copy of ``points`` given the image dimensions."""
 
         return scale_points_to_pixels(self.points, width=width, height=height, clamp=clamp)
+
+    def boxes_to_pixels(self, width: int, height: int, *, clamp: bool = True) -> list[BoundingBox] | None:
+        """Return a pixel-space copy of ``boxes`` given the image dimensions."""
+
+        return scale_points_to_pixels(self.boxes, width=width, height=height, clamp=clamp)
+
+    def polygons_to_pixels(self, width: int, height: int, *, clamp: bool = True) -> list[Polygon] | None:
+        """Return a pixel-space copy of ``polygons`` given the image dimensions."""
+
+        return scale_points_to_pixels(self.polygons, width=width, height=height, clamp=clamp)
 
 
 def _prepare_client_kwargs(
@@ -459,15 +471,13 @@ def _maybe_compile_only_result(
 
 
 def _perceive_result_from_response(resp: dict, issues: list[dict]) -> PerceiveResult:
-    text = resp.get("text")
-    points = resp.get("points")
-    parsed = resp.get("parsed")
-    reasoning = resp.get("reasoning")
     return PerceiveResult(
-        text=text,
-        points=points,
-        parsed=parsed,
-        reasoning=reasoning,
+        text=resp.get("text"),
+        points=resp.get("points"),
+        boxes=resp.get("boxes"),
+        polygons=resp.get("polygons"),
+        parsed=resp.get("parsed"),
+        reasoning=resp.get("reasoning"),
         usage=None,
         errors=issues,
         raw=resp.get("raw"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,8 @@ class _StubResult(PerceiveResult):
         super().__init__(
             text=text,
             points=None,
+            boxes=None,
+            polygons=None,
             parsed=None,
             reasoning=None,
             usage=None,
@@ -134,7 +136,7 @@ def test_detect_command_directory(monkeypatch, tmp_path):
     def _fake_detect(data, *, classes=None):
         assert classes == ["person"]
         res = _StubResult("detected-one" if data == b"image-one" else "detected-two")
-        res.points = [
+        res.boxes = [
             BoundingBox(
                 top_left=SinglePoint(1, 2, mention="person"),
                 bottom_right=SinglePoint(3, 4),
@@ -151,10 +153,10 @@ def test_detect_command_directory(monkeypatch, tmp_path):
     data = json.loads(output_path.read_text())
     assert set(data.keys()) == {"one.png", "two.jpg"}
     assert data["one.png"]["text"] == "detected-one"
-    points = data["one.png"].get("points")
-    assert points and points[0]["type"] == "box"
-    assert points[0]["top_left"]["x"] == 1
-    assert points[0]["top_left"]["mention"] == "person"
+    boxes = data["one.png"].get("boxes")
+    assert boxes and boxes[0]["type"] == "box"
+    assert boxes[0]["top_left"]["x"] == 1
+    assert boxes[0]["top_left"]["mention"] == "person"
 
 
 def test_detect_command_stream(monkeypatch):
@@ -191,7 +193,7 @@ def test_question_command(monkeypatch):
 
 def test_question_command_box_json(monkeypatch):
     res = _StubResult("box answer")
-    res.points = [
+    res.boxes = [
         BoundingBox(
             top_left=SinglePoint(1, 2, mention="item"),
             bottom_right=SinglePoint(3, 4),
@@ -214,7 +216,7 @@ def test_question_command_box_json(monkeypatch):
     assert result.exit_code == 0
     payload = json.loads(result.stdout)
     assert payload["text"] == "box answer"
-    assert payload["points"][0]["type"] == "box"
+    assert payload["boxes"][0]["type"] == "box"
 
 
 def test_config_command():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,8 +4,14 @@ import pytest
 from typer.testing import CliRunner
 
 from perceptron import PerceiveResult
-from perceptron.cli import app
-from perceptron.pointing.types import BoundingBox, SinglePoint
+from perceptron.cli import (
+    OutputFormat,
+    _bucket_for_expects,
+    _coerce_result_dict,
+    _stream_render,
+    app,
+)
+from perceptron.pointing.types import BoundingBox, Polygon, SinglePoint
 
 
 @pytest.fixture(autouse=True)
@@ -224,3 +230,197 @@ def test_config_command():
     assert result.exit_code == 0
     assert "PERCEPTRON_PROVIDER=fal" in result.stdout
     assert "PERCEPTRON_API_KEY=abc" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Per-kind JSON output coverage
+# ---------------------------------------------------------------------------
+
+
+def test_caption_command_box_json_emits_boxes_key(monkeypatch):
+    res = _StubResult("describe")
+    res.boxes = [
+        BoundingBox(
+            top_left=SinglePoint(10, 20, mention="lamp"),
+            bottom_right=SinglePoint(30, 40),
+            mention="lamp",
+        )
+    ]
+    monkeypatch.setattr("perceptron.cli.caption_image", lambda *a, **k: res)
+    result = runner.invoke(
+        app,
+        ["caption", "https://example.com/img", "--expects", "box", "--format", "json"],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["boxes"][0]["type"] == "box"
+    assert "points" not in payload
+    assert "polygons" not in payload
+
+
+def test_question_command_point_json_emits_points_key(monkeypatch):
+    res = _StubResult("center")
+    res.points = [SinglePoint(50, 60, mention="middle")]
+    monkeypatch.setattr("perceptron.cli.question_image", lambda *a, **k: res)
+    result = runner.invoke(
+        app,
+        [
+            "question",
+            "https://example.com/img",
+            "Where is the center?",
+            "--expects",
+            "point",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["points"][0]["type"] == "point"
+    assert "boxes" not in payload
+    assert "polygons" not in payload
+
+
+def test_question_command_polygon_json_emits_polygons_key(monkeypatch):
+    res = _StubResult("region")
+    res.polygons = [
+        Polygon(
+            hull=[SinglePoint(0, 0), SinglePoint(10, 0), SinglePoint(5, 10)],
+            mention="hull",
+        )
+    ]
+    monkeypatch.setattr("perceptron.cli.question_image", lambda *a, **k: res)
+    result = runner.invoke(
+        app,
+        [
+            "question",
+            "https://example.com/img",
+            "Outline the region.",
+            "--expects",
+            "polygon",
+            "--format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["polygons"][0]["type"] == "polygon"
+    assert "boxes" not in payload
+    assert "points" not in payload
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_for_expects_routes_each_kind():
+    res = _StubResult("x")
+    res.points = [SinglePoint(1, 1)]
+    res.boxes = [BoundingBox(top_left=SinglePoint(0, 0), bottom_right=SinglePoint(2, 2))]
+    res.polygons = [Polygon(hull=[SinglePoint(0, 0), SinglePoint(2, 0), SinglePoint(1, 2)])]
+
+    assert _bucket_for_expects(res, "point") == ("points", res.points)
+    assert _bucket_for_expects(res, "box") == ("boxes", res.boxes)
+    assert _bucket_for_expects(res, "polygon") == ("polygons", res.polygons)
+
+
+def test_bucket_for_expects_returns_none_for_unsupported():
+    res = _StubResult("x")
+    res.boxes = [BoundingBox(top_left=SinglePoint(0, 0), bottom_right=SinglePoint(1, 1))]
+
+    # `text`/`think`/None aren't in the bucket map.
+    assert _bucket_for_expects(res, "text") is None
+    assert _bucket_for_expects(res, "think") is None
+    assert _bucket_for_expects(res, None) is None
+
+
+def test_bucket_for_expects_returns_none_when_bucket_empty():
+    res = _StubResult("x")
+    # boxes is None — nothing to surface.
+    assert _bucket_for_expects(res, "box") is None
+
+
+def test_coerce_result_dict_normalizes_all_buckets():
+    box = BoundingBox(top_left=SinglePoint(1, 1), bottom_right=SinglePoint(2, 2))
+    coerced = _coerce_result_dict({"text": "hi", "boxes": [box]})
+
+    # All three bucket fields are present (None for missing ones).
+    assert coerced["text"] == "hi"
+    assert coerced["boxes"] == [box]
+    assert coerced["points"] is None
+    assert coerced["polygons"] is None
+    assert coerced["errors"] == []
+
+
+# ---------------------------------------------------------------------------
+# Streaming
+# ---------------------------------------------------------------------------
+
+
+def test_stream_render_routes_box_final_event_into_boxes_bucket(monkeypatch):
+    """Streaming `final` event with a `boxes` field should reach the JSON output under `boxes`."""
+
+    box = BoundingBox(
+        top_left=SinglePoint(1, 2, mention="cat"),
+        bottom_right=SinglePoint(3, 4),
+        mention="cat",
+    )
+    events = [
+        {"type": "text.delta", "chunk": "found one"},
+        {"type": "final", "result": {"text": "found one", "boxes": [box]}},
+    ]
+
+    captured: dict[str, object] = {}
+
+    def _fake_print_json(*, data):
+        captured["payload"] = data
+
+    monkeypatch.setattr("perceptron.cli.console.print_json", _fake_print_json)
+
+    _stream_render(
+        iter(events),
+        title="Detect",
+        output_format=OutputFormat.JSON,
+        show_raw=False,
+        show_points_table=True,
+        expects="box",
+    )
+
+    payload = captured["payload"]
+    assert payload["text"] == "found one"
+    assert payload["boxes"][0]["type"] == "box"
+    assert "points" not in payload
+    assert "polygons" not in payload
+
+
+def test_stream_render_buffers_points_delta_into_correct_bucket(monkeypatch):
+    """Buffered `points.delta` events should be surfaced under the bucket matching `expects`."""
+
+    poly = Polygon(hull=[SinglePoint(0, 0), SinglePoint(10, 0), SinglePoint(5, 10)])
+    events = [
+        {"type": "points.delta", "points": [poly]},
+        {"type": "text.delta", "chunk": "ok"},
+        # No `final` event; render falls back to the buffered points.
+    ]
+
+    captured: dict[str, object] = {}
+
+    def _fake_print_json(*, data):
+        captured["payload"] = data
+
+    monkeypatch.setattr("perceptron.cli.console.print_json", _fake_print_json)
+
+    _stream_render(
+        iter(events),
+        title="Question",
+        output_format=OutputFormat.JSON,
+        show_raw=False,
+        show_points_table=False,
+        expects="polygon",
+    )
+
+    payload = captured["payload"]
+    assert payload["polygons"][0]["type"] == "polygon"
+    assert "points" not in payload
+    assert "boxes" not in payload

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -424,3 +424,56 @@ def test_stream_render_buffers_points_delta_into_correct_bucket(monkeypatch):
     assert payload["polygons"][0]["type"] == "polygon"
     assert "points" not in payload
     assert "boxes" not in payload
+
+
+def test_stream_render_accumulates_text_deltas(monkeypatch):
+    """Multiple `text.delta` events should be concatenated and surfaced as `text`."""
+
+    events = [
+        {"type": "text.delta", "chunk": "hello "},
+        {"type": "text.delta", "chunk": "world"},
+        # No final event — render must fall back to buffered text.
+    ]
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "perceptron.cli.console.print_json",
+        lambda *, data: captured.update(payload=data),
+    )
+
+    _stream_render(
+        iter(events),
+        title="Caption",
+        output_format=OutputFormat.JSON,
+        show_raw=False,
+        show_points_table=False,
+        expects=None,
+    )
+
+    assert captured["payload"]["text"] == "hello world"
+
+
+def test_stream_render_final_text_overrides_buffer(monkeypatch):
+    """If the `final` event carries `text`, it should replace the streamed buffer."""
+
+    events = [
+        {"type": "text.delta", "chunk": "draft"},
+        {"type": "final", "result": {"text": "authoritative"}},
+    ]
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(
+        "perceptron.cli.console.print_json",
+        lambda *, data: captured.update(payload=data),
+    )
+
+    _stream_render(
+        iter(events),
+        title="Caption",
+        output_format=OutputFormat.JSON,
+        show_raw=False,
+        show_points_table=False,
+        expects=None,
+    )
+
+    assert captured["payload"]["text"] == "authoritative"

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -57,8 +57,8 @@ def test_docs_capabilities_captioning_example():
     assert isinstance(text_only.text, str)
     assert text_only.text.strip() != ""
     assert "choices" in boxes.raw
-    assert boxes.points is not None and len(boxes.points) >= 1
-    pixel_points = boxes.points_to_pixels(1920, 1080)
+    assert boxes.boxes is not None and len(boxes.boxes) >= 1
+    pixel_points = boxes.boxes_to_pixels(1920, 1080)
     assert pixel_points is not None
     for scaled in pixel_points:
         assert 0 <= scaled.top_left.x < scaled.bottom_right.x <= 1920
@@ -120,8 +120,8 @@ def test_docs_perceive_direct_invocation_examples():
 
     assert isinstance(text_only.text, str)
     assert text_only.text.strip() != ""
-    assert boxed.points is not None and len(boxed.points) >= 1
-    for box_result in boxed.points:
+    assert boxed.boxes is not None and len(boxed.boxes) >= 1
+    for box_result in boxed.boxes:
         assert 0 <= box_result.top_left.x < box_result.bottom_right.x <= 1000
         assert 0 <= box_result.top_left.y < box_result.bottom_right.y <= 1000
 
@@ -140,10 +140,10 @@ def test_docs_capabilities_object_detection_example():
         )
 
     assert isinstance(result.raw, dict)
-    assert result.points is not None and len(result.points) >= 1
-    mentions = {box_result.mention.lower() for box_result in result.points if box_result.mention}
+    assert result.boxes is not None and len(result.boxes) >= 1
+    mentions = {box_result.mention.lower() for box_result in result.boxes if box_result.mention}
     assert mentions.intersection({"helmet", "vest"})
-    for box_result in result.points:
+    for box_result in result.boxes:
         # Docs promise normalized geometry (0-1000 grid) for each detection.
         assert 0 <= box_result.top_left.x < box_result.bottom_right.x <= 1000
         assert 0 <= box_result.top_left.y < box_result.bottom_right.y <= 1000
@@ -174,8 +174,8 @@ def test_docs_capabilities_visual_qa_example():
 
     assert isinstance(result.text, str)
     assert result.text.strip() != ""
-    assert result.points is not None and len(result.points) >= 1
-    for answer_box in result.points:
+    assert result.boxes is not None and len(result.boxes) >= 1
+    for answer_box in result.boxes:
         assert 0 <= answer_box.top_left.x < answer_box.bottom_right.x <= 1000
         assert 0 <= answer_box.top_left.y < answer_box.bottom_right.y <= 1000
 
@@ -197,9 +197,9 @@ def test_docs_concepts_coordinate_helpers():
 
     assert (scaled.top_left.x, scaled.top_left.y, scaled.bottom_right.x, scaled.bottom_right.y) == expected
 
-    # Per docs, PerceiveResult.points_to_pixels is the one-liner wrapper
-    result_stub = PerceiveResult(text="", points=[normalized_box], parsed=None, reasoning=None, usage=None, errors=[], raw={})
-    pixel_points = result_stub.points_to_pixels(width, height)
+    # Per docs, PerceiveResult.boxes_to_pixels is the one-liner wrapper
+    result_stub = PerceiveResult(text="", points=None, boxes=[normalized_box], polygons=None, parsed=None, reasoning=None, usage=None, errors=[], raw={})
+    pixel_points = result_stub.boxes_to_pixels(width, height)
     assert pixel_points is not None
     assert isinstance(pixel_points[0], type(scaled))
 
@@ -217,8 +217,8 @@ def test_docs_in_context_single_example():
             classes=["objectCategory1"],
         )
 
-        assert bootstrap.points is not None and len(bootstrap.points) >= 1
-        first_box = bootstrap.points[0]
+        assert bootstrap.boxes is not None and len(bootstrap.boxes) >= 1
+        first_box = bootstrap.boxes[0]
         example_shot = annotate_image(
             exemplar_path,
             {
@@ -240,8 +240,8 @@ def test_docs_in_context_single_example():
             examples=[example_shot],
         )
 
-    assert result.points is not None and len(result.points) >= 1
-    assert all((box.mention or "objectCategory1").startswith("objectCategory1") for box in result.points)
+    assert result.boxes is not None and len(result.boxes) >= 1
+    assert all((box.mention or "objectCategory1").startswith("objectCategory1") for box in result.boxes)
 
 
 @pytest.mark.integration
@@ -268,8 +268,8 @@ def test_docs_in_context_multi_example():
             examples=[cat_example, dog_example],
         )
 
-    assert result.points is not None and len(result.points) >= 1
-    mentions = {box.mention for box in result.points if box.mention}
+    assert result.boxes is not None and len(result.boxes) >= 1
+    mentions = {box.mention for box in result.boxes if box.mention}
     assert mentions.intersection({"classA", "classB"})
 
 
@@ -346,7 +346,7 @@ def test_docs_pointing_basics_example():
     with config(**{k: v for k, v in _live_config_kwargs().items() if v is not None}):
         result = locate_defect(frame_path)
 
-    assert isinstance(result.points, list) or result.points is None
+    assert isinstance(result.boxes, list) or result.boxes is None
 
 
 def test_docs_pointing_basics_collection_snippet():
@@ -410,4 +410,4 @@ def test_docs_scaling_low_latency_example():
     with config(**cfg):
         result = detect(image(sample_image), classes=["scratch"], expects="box")
 
-    assert isinstance(result.points, list) or result.points is None
+    assert isinstance(result.boxes, list) or result.boxes is None

--- a/tests/test_examples_icl_detection_integration.py
+++ b/tests/test_examples_icl_detection_integration.py
@@ -67,14 +67,14 @@ def test_detect_examples_pipeline_hits_backend():
 
     assert isinstance(result.raw, dict)
     assert result.raw.get("choices"), "Expected backend to return choices"
-    assert result.points, "Backend did not return any bounding boxes"
+    assert result.boxes, "Backend did not return any bounding boxes"
 
     with Image.open(_TARGET_IMAGE) as im:
         width, height = im.size
 
     expected_box = bbox(38, 91, 934, 962, mention="classB")
     expected_pixels = scale_points_to_pixels([expected_box], width=width, height=height)[0]
-    pixel_predictions = result.points_to_pixels(width, height)
+    pixel_predictions = result.boxes_to_pixels(width, height)
     assert pixel_predictions, "Point scaling produced no boxes"
 
     best_match = max(pixel_predictions, key=lambda pt: _intersection_over_union(pt, expected_pixels))

--- a/tests/test_highlevel_detect.py
+++ b/tests/test_highlevel_detect.py
@@ -222,9 +222,9 @@ def test_detect_flattens_collection_response(monkeypatch):
         res = detect(image(PNG_BYTES), classes=["dog"])
 
     assert res.text and "<collection" in res.text
-    assert res.points and len(res.points) == 2
-    assert res.points[0].mention == "dog"
-    assert res.points[1].mention == "named"
+    assert res.boxes and len(res.boxes) == 2
+    assert res.boxes[0].mention == "dog"
+    assert res.boxes[1].mention == "named"
 
 
 def test_detect_from_coco(monkeypatch, tmp_path):

--- a/tests/test_point_scaling.py
+++ b/tests/test_point_scaling.py
@@ -59,11 +59,13 @@ def test_scale_points_to_pixels_rejects_bad_dimensions():
         scale_points_to_pixels([], width=0, height=10)
 
 
-def test_perceive_result_points_to_pixels_returns_copy():
+def test_perceive_result_boxes_to_pixels_returns_copy():
     raw_box = bbox(0, 0, 1000, 1000, mention="full")
     result = PerceiveResult(
         text=None,
-        points=[raw_box],
+        points=None,
+        boxes=[raw_box],
+        polygons=None,
         parsed=None,
         reasoning=None,
         usage=None,
@@ -71,7 +73,7 @@ def test_perceive_result_points_to_pixels_returns_copy():
         raw=None,
     )
 
-    scaled = result.points_to_pixels(400, 200)
+    scaled = result.boxes_to_pixels(400, 200)
     assert scaled and scaled[0].bottom_right.x == 399
     # Original remains normalized
-    assert result.points[0].bottom_right.x == 1000
+    assert result.boxes[0].bottom_right.x == 1000

--- a/tests/test_transport_payloads.py
+++ b/tests/test_transport_payloads.py
@@ -113,7 +113,7 @@ def test_fal_payload_structure(monkeypatch):
     assert assistant and isinstance(assistant[0]["content"], str)
 
     # Perceive result should surface parsed boxes from response text
-    assert res.points and res.points[0].top_left.x == 1
+    assert res.boxes and res.boxes[0].top_left.x == 1
 
 
 def test_image_url_passthrough():


### PR DESCRIPTION
## Summary

  Splits `PerceiveResult.points` into per-kind buckets — `points`, `boxes`, `polygons` — matching the Rust SDK's `Pointing` shape. The previous flat `points: list[Any]` field held a mixed bag (boxes when `expects="box"`, points when `expects="point"`, etc.), which was a misnomer and lossy on heterogeneous responses.

  Breaking change for any caller that read `result.points` after `detect()`, `caption(..., expects="box")`, or `question(..., expects="box")` — those now live in `result.boxes`.

  ## What's new

  **`PerceiveResult` shape** (`dsl/perceive.py`)
  - `points: list[SinglePoint] | None` — points only.
  - `boxes: list[BoundingBox] | None` — new.
  - `polygons: list[Polygon] | None` — new.
  - New `boxes_to_pixels()` and `polygons_to_pixels()` convenience methods alongside the existing `points_to_pixels()`. Each scales its own bucket.
  - Population rule (matches Rust): only the bucket matching `expects` is populated; the other two stay `None`.

  **Client** (`client.py`)
  - Added `_BUCKET_BY_EXPECTS = {"point": "points", "box": "boxes", "polygon": "polygons"}` and dispatches in both non-streaming `_build_result` and streaming `_StreamProcessor.finalize`.
  - Streaming `final` event payload now matches the non-streaming dict shape — only the populated bucket is present, missing buckets aren't emitted as `None`.

  **CLI** (`cli.py`)
  - Added `_bucket_for_expects(result, expects)` to look up the populated bucket by `expects` rather than scanning.
  - JSON output now emits the kind-specific key honestly: `{"text": ..., "boxes": [...]}` for detect, `{"points": [...]}` for point queries, `{"polygons": [...]}` for polygon queries.
  - Streaming `_stream_render` resolves the bucket name once and uses it consistently when reading and merging the `final` event.