### PR TITLE
Quickstart notebooks: rewrite image as Q&A and add video Q&A for Isaac 0.3 Max

### DIFF
--- a/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb
+++ b/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb
@@ -42,17 +42,7 @@
    "cell_type": "markdown",
    "id": "qsisaac-intro",
    "metadata": {},
-   "source": [
-    "Ask Isaac 0.3 Max a question about an image and get a natural-language answer back. This quickstart configures the Perceptron SDK, downloads a sample image, and runs a single Q&A call.\n",
-    "\n",
-    "![Studio scene sample](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp)\n",
-    "\n",
-    "**Note**\n",
-    "\n",
-    "Set the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or image for your own at any time.\n",
-    "\n",
-    "----"
-   ]
+   "source": "Ask Isaac 0.3 Max a question about an image and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample image URL — no local download needed.\n\n![Studio scene sample](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp)\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or image (URL or local file path) for your own at any time.\n\n----"
   },
   {
    "cell_type": "markdown",
@@ -74,26 +64,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-dlhdr",
-   "metadata": {},
-   "source": [
-    "## Download the sample image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "qsisaac-dl",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "IMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp\"\n",
-    "\n",
-    "!curl -so studio_scene.webp {IMAGE_URL}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "qsisaac-confhdr",
    "metadata": {},
    "source": [
@@ -107,23 +77,7 @@
    "id": "qsisaac-conf",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "from perceptron import configure, image, question\n",
-    "\n",
-    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
-    "if not api_key or api_key.startswith(\"<\"):\n",
-    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
-    "\n",
-    "configure(\n",
-    "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
-    "    api_key=api_key,\n",
-    ")\n",
-    "\n",
-    "IMAGE_PATH = \"studio_scene.webp\""
-   ]
+   "source": "import os\n\nfrom perceptron import configure, image, question\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.3-max\",\n    api_key=api_key,\n)\n\nIMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp\""
   },
   {
    "cell_type": "markdown",
@@ -139,25 +93,13 @@
    "id": "qsisaac-ask",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "QUESTION = \"What is in this image?\"\n",
-    "\n",
-    "result = question(image(IMAGE_PATH), QUESTION)\n",
-    "print(result.text)"
-   ]
+   "source": "QUESTION = \"What is in this image?\"\n\nresult = question(image(IMAGE_URL), QUESTION)\nprint(result.text)"
   },
   {
    "cell_type": "markdown",
    "id": "qsisaac-next",
    "metadata": {},
-   "source": [
-    "## Next steps\n",
-    "- Swap `IMAGE_PATH` for your own image (URL or local file path).\n",
-    "- Tune `QUESTION` toward inspections, retrieval, or scene description.\n",
-    "- Pass `expects=\"box\"`, `\"point\"`, or `\"polygon\"` to receive grounded annotations alongside the answer.\n",
-    "- See the [Image Q&A capability guide](https://docs.perceptron.inc/capabilities/visual-qa) for grounded responses with bounding-box overlays.\n",
-    "- For video inputs, see the [video quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb)."
-   ]
+   "source": "## Next steps\n- Swap `IMAGE_URL` for your own image (URL or local file path — `image()` accepts both).\n- Tune `QUESTION` toward inspections, retrieval, or scene description.\n- Pass `expects=\"box\"`, `\"point\"`, or `\"polygon\"` to receive grounded annotations alongside the answer.\n- See the [Image Q&A capability guide](https://docs.perceptron.inc/capabilities/visual-qa) for grounded responses with bounding-box overlays.\n- For video inputs, see the [video quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb)."
   }
  ],
  "metadata": {

--- a/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
+++ b/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
@@ -42,7 +42,19 @@
    "cell_type": "markdown",
    "id": "qsvideo-intro",
    "metadata": {},
-   "source": "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample video URL — no local download needed.\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4 or WebM URL or local file path) for your own at any time.\n\n----"
+   "source": [
+    "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample video URL — no local download needed.\n",
+    "\n",
+    "<video src=\"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\" controls width=\"640\" muted loop>\n",
+    "  Your browser doesn't support the video tag.\n",
+    "</video>\n",
+    "\n",
+    "**Note**\n",
+    "\n",
+    "Set the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4 or WebM URL or local file path) for your own at any time.\n",
+    "\n",
+    "----"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
+++ b/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
@@ -42,7 +42,7 @@
    "cell_type": "markdown",
    "id": "qsvideo-intro",
    "metadata": {},
-   "source": "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK, downloads a sample video, and runs a single Q&A call.\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4 or WebM) for your own at any time.\n\n----"
+   "source": "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample video URL — no local download needed.\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4 or WebM URL or local file path) for your own at any time.\n\n----"
   },
   {
    "cell_type": "markdown",
@@ -64,26 +64,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "qsvideo-dlhdr",
-   "metadata": {},
-   "source": [
-    "## Download the sample video"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "qsvideo-dl",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "VIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\"\n",
-    "\n",
-    "!curl -L -so surf.mp4 {VIDEO_URL}"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "qsvideo-confhdr",
    "metadata": {},
    "source": [
@@ -97,23 +77,7 @@
    "id": "qsvideo-conf",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import os\n",
-    "\n",
-    "from perceptron import configure, question, video\n",
-    "\n",
-    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
-    "if not api_key or api_key.startswith(\"<\"):\n",
-    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
-    "\n",
-    "configure(\n",
-    "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
-    "    api_key=api_key,\n",
-    ")\n",
-    "\n",
-    "VIDEO_PATH = \"surf.mp4\""
-   ]
+   "source": "import os\n\nfrom perceptron import configure, question, video\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.3-max\",\n    api_key=api_key,\n)\n\nVIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\""
   },
   {
    "cell_type": "markdown",
@@ -129,18 +93,13 @@
    "id": "qsvideo-ask",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "QUESTION = \"What happens in this video?\"\n",
-    "\n",
-    "result = question(video(VIDEO_PATH), QUESTION)\n",
-    "print(result.text)"
-   ]
+   "source": "QUESTION = \"What happens in this video?\"\n\nresult = question(video(VIDEO_URL), QUESTION)\nprint(result.text)"
   },
   {
    "cell_type": "markdown",
    "id": "qsvideo-next",
    "metadata": {},
-   "source": "## Next steps\n- Swap `VIDEO_PATH` for your own MP4 or WebM (URL or local file path).\n- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)."
+   "source": "## Next steps\n- Swap `VIDEO_URL` for your own MP4 or WebM (URL or local file path — `video()` accepts both).\n- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)."
   }
  ],
  "metadata": {

--- a/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
+++ b/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
@@ -42,15 +42,7 @@
    "cell_type": "markdown",
    "id": "qsvideo-intro",
    "metadata": {},
-   "source": [
-    "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK, downloads a sample video, and runs a single Q&A call.\n",
-    "\n",
-    "**Note**\n",
-    "\n",
-    "Set the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4) for your own at any time.\n",
-    "\n",
-    "----"
-   ]
+   "source": "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK, downloads a sample video, and runs a single Q&A call.\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4 or WebM) for your own at any time.\n\n----"
   },
   {
    "cell_type": "markdown",
@@ -148,13 +140,7 @@
    "cell_type": "markdown",
    "id": "qsvideo-next",
    "metadata": {},
-   "source": [
-    "## Next steps\n",
-    "- Swap `VIDEO_PATH` for your own MP4 (URL or local file path).\n",
-    "- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n",
-    "- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n",
-    "- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)."
-   ]
+   "source": "## Next steps\n- Swap `VIDEO_PATH` for your own MP4 or WebM (URL or local file path).\n- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)."
   }
  ],
  "metadata": {

--- a/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
+++ b/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "qsisaac-cprt",
+   "id": "qsvideo-cprt",
    "metadata": {},
    "source": [
     "##### Copyright 2025 Perceptron AI."
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "qsisaac-lic",
+   "id": "qsvideo-lic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,33 +30,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-title",
+   "id": "qsvideo-title",
    "metadata": {},
    "source": [
-    "# Get started with Isaac 0.3 Max — Image\n",
+    "# Get started with Isaac 0.3 Max — Video\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-intro",
+   "id": "qsvideo-intro",
    "metadata": {},
    "source": [
-    "Ask Isaac 0.3 Max a question about an image and get a natural-language answer back. This quickstart configures the Perceptron SDK, downloads a sample image, and runs a single Q&A call.\n",
-    "\n",
-    "![Studio scene sample](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp)\n",
+    "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK, downloads a sample video, and runs a single Q&A call.\n",
     "\n",
     "**Note**\n",
     "\n",
-    "Set the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or image for your own at any time.\n",
+    "Set the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or video (MP4) for your own at any time.\n",
     "\n",
     "----"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-installhdr",
+   "id": "qsvideo-installhdr",
    "metadata": {},
    "source": [
     "## Install dependencies"
@@ -65,7 +63,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "qsisaac-install",
+   "id": "qsvideo-install",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,27 +72,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-dlhdr",
+   "id": "qsvideo-dlhdr",
    "metadata": {},
    "source": [
-    "## Download the sample image"
+    "## Download the sample video"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "qsisaac-dl",
+   "id": "qsvideo-dl",
    "metadata": {},
    "outputs": [],
    "source": [
-    "IMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp\"\n",
+    "VIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\"\n",
     "\n",
-    "!curl -so studio_scene.webp {IMAGE_URL}"
+    "!curl -L -so surf.mp4 {VIDEO_URL}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-confhdr",
+   "id": "qsvideo-confhdr",
    "metadata": {},
    "source": [
     "## Configure the Perceptron client\n",
@@ -104,13 +102,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "qsisaac-conf",
+   "id": "qsvideo-conf",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
-    "from perceptron import configure, image, question\n",
+    "from perceptron import configure, question, video\n",
     "\n",
     "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
     "if not api_key or api_key.startswith(\"<\"):\n",
@@ -122,41 +120,40 @@
     "    api_key=api_key,\n",
     ")\n",
     "\n",
-    "IMAGE_PATH = \"studio_scene.webp\""
+    "VIDEO_PATH = \"surf.mp4\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-askhdr",
+   "id": "qsvideo-askhdr",
    "metadata": {},
    "source": [
-    "## Ask a question about the image"
+    "## Ask a question about the video"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "qsisaac-ask",
+   "id": "qsvideo-ask",
    "metadata": {},
    "outputs": [],
    "source": [
-    "QUESTION = \"What is in this image?\"\n",
+    "QUESTION = \"What happens in this video?\"\n",
     "\n",
-    "result = question(image(IMAGE_PATH), QUESTION)\n",
+    "result = question(video(VIDEO_PATH), QUESTION)\n",
     "print(result.text)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "qsisaac-next",
+   "id": "qsvideo-next",
    "metadata": {},
    "source": [
     "## Next steps\n",
-    "- Swap `IMAGE_PATH` for your own image (URL or local file path).\n",
-    "- Tune `QUESTION` toward inspections, retrieval, or scene description.\n",
-    "- Pass `expects=\"box\"`, `\"point\"`, or `\"polygon\"` to receive grounded annotations alongside the answer.\n",
-    "- See the [Image Q&A capability guide](https://docs.perceptron.inc/capabilities/visual-qa) for grounded responses with bounding-box overlays.\n",
-    "- For video inputs, see the [video quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb)."
+    "- Swap `VIDEO_PATH` for your own MP4 (URL or local file path).\n",
+    "- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n",
+    "- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n",
+    "- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Rewrites `cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb` from a detection example to a minimal Q&A walkthrough using `isaac-0.3-max` and the `studio_scene.webp` asset.
- Adds `cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb` mirroring the same shape with the `surf.mp4` asset, demonstrating `question(video(...), ...)` for video Q&A.

## Why
The upcoming Quickstart docs refresh on docs.perceptron.inc will surface two Colab badges — "Get started with Image" and "Get started with Video" — pointing at these notebooks. Both need to land before the docs PR (PR 1b) so the Colab links resolve. Detection content previously in the image quickstart is already well-covered by `cookbook/recipes/capabilities/object-detection/`.

## Pairs with
- Docs PR (mintlify_docs) updating the Quickstart page to link both notebooks — opening next once this lands.

## Follow-up
- The genesis registry (`genesis/product/service/utils/src/model/registry.rs:187`) currently has stale values for `isaac-0.3-max` (context 24,576 → should be 32,768; pricing 500_000/2_500_000 → should be 200_000/1_500_000). The deployed Modal config (`modal_server/config.py:121`) already uses `context_length: 32768`. Not blocking these notebooks but worth fixing.

## Test plan
- [x] Open both notebooks in Colab and run end-to-end with a valid `PERCEPTRON_API_KEY`.
- [x] Confirm `isaac-0.3-max` accepts the request and returns a sensible answer for each.
- [ ] Confirm Colab badge link resolves to the notebook on `main` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)