### PR TITLE
SDK v0.3.1 polish: isaac-0.3-max allowlist + CLI media awareness + CLI clip render

### DIFF
--- a/src/perceptron/cli.py
+++ b/src/perceptron/cli.py
@@ -77,10 +77,6 @@ def _resolve_media(media: str) -> str | bytes:
     return media
 
 
-# Back-compat alias for callers that still want image-only resolution semantics.
-_resolve_image = _resolve_media
-
-
 def _looks_like_video(media: str) -> bool:
     """True if the path or URL ends with a known video extension."""
 

--- a/src/perceptron/cli.py
+++ b/src/perceptron/cli.py
@@ -19,8 +19,10 @@ from rich.text import Text
 
 from . import caption as caption_image
 from . import detect as detect_image
+from . import image as image_node
 from . import ocr as ocr_image
 from . import question as question_image
+from . import video as video_node
 from .pointing.types import BoundingBox, Clip, Collection, Polygon, SinglePoint
 
 console = Console()
@@ -38,6 +40,8 @@ _IMAGE_EXTENSIONS = {
     ".heic",
     ".heif",
 }
+
+_VIDEO_EXTENSIONS = {".mp4"}
 
 _OUTPUT_FILENAMES = {
     "caption": "captions.json",
@@ -60,15 +64,36 @@ class ExpectationType(str, Enum):
     THINK = "think"
 
 
-def _resolve_image(image: str) -> str | bytes:
-    if image.startswith(("http://", "https://")):
-        return image
-    path = Path(image)
+def _resolve_media(media: str) -> str | bytes:
+    """Resolve a media argument to a URL string or local-file bytes."""
+
+    if media.startswith(("http://", "https://")):
+        return media
+    path = Path(media)
     if path.is_dir():
-        raise ValueError(f"Expected image file, received directory: {image}")
+        raise ValueError(f"Expected media file, received directory: {media}")
     if path.exists():
         return path.read_bytes()
-    return image
+    return media
+
+
+# Back-compat alias for callers that still want image-only resolution semantics.
+_resolve_image = _resolve_media
+
+
+def _looks_like_video(media: str) -> bool:
+    """True if the path or URL ends with a known video extension."""
+
+    base = media.lower().split("?", 1)[0].split("#", 1)[0]
+    return any(base.endswith(ext) for ext in _VIDEO_EXTENSIONS)
+
+
+def _make_media_node(media_input: str, media_data: str | bytes):
+    """Wrap resolved media data in `image()` or `video()` based on the input's extension."""
+
+    if _looks_like_video(media_input):
+        return video_node(media_data)
+    return image_node(media_data)
 
 
 def _iter_image_files(directory: Path) -> Iterable[Path]:
@@ -345,6 +370,10 @@ def _describe_point(point: Any) -> tuple[str, str, str]:
         return ("polygon", coords, point.mention or "")
     if isinstance(point, Collection):
         return ("collection", f"{len(point.points)} items", point.mention or "")
+    if isinstance(point, Clip):
+        ts = point.timestamp
+        coords = f"@{ts.at:.2f}s" if ts.until is None else f"{ts.at:.2f}s → {ts.until:.2f}s"
+        return ("clip", coords, point.mention or "")
     return (type(point).__name__, str(point), getattr(point, "mention", "") or "")
 
 
@@ -607,6 +636,16 @@ def _render_result(
         for point in items:
             table.add_row(str(point), getattr(point, "mention", ""))
         console.print(table)
+    elif expects == "clip" and populated is not None:
+        _, items = populated
+        table = Table(title="Clips", show_header=True, header_style="bold blue")
+        table.add_column("type")
+        table.add_column("timestamp")
+        table.add_column("mention")
+        for clip in items:
+            kind, coords, mention = _describe_point(clip)
+            table.add_row(kind, coords, mention)
+        console.print(table)
     elif populated is not None:
         bucket_name, items = populated
         console.print_json(data={bucket_name: _serialize_points(items)})
@@ -643,7 +682,7 @@ def config(
 
 @app.command()
 def caption(
-    image: str = typer.Argument(..., help="Image path or URL."),
+    media: str = typer.Argument(..., help="Image or video path or URL."),
     style: str = typer.Option("concise", help="Captioning style."),
     stream: bool = typer.Option(False, help="Stream incremental output."),
     show_raw: bool = typer.Option(False, help="Display raw response JSON."),
@@ -658,33 +697,34 @@ def caption(
         ExpectationType.BOX,
         "--expects",
         case_sensitive=False,
-        help="Expected output structure (text, point, box, polygon, or think).",
+        help="Expected output structure (text, point, box, polygon, clip, or think).",
     ),
 ):
     """Generate captions using the high-level helper."""
 
-    path = Path(image)
+    path = Path(media)
     if path.is_dir():
         _process_directory(
             path,
             command_name="caption",
             stream=stream,
             show_raw=show_raw,
-            runner=lambda data: caption_image(data, style=style, expects=expects.value),
+            runner=lambda data: caption_image(image_node(data), style=style, expects=expects.value),
             payload_factory=lambda result: _caption_payload(result, expects=expects.value),
         )
         return
 
     try:
-        img = _resolve_image(image)
+        media_data = _resolve_media(media)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
+    node = _make_media_node(media, media_data)
     expects_value = expects.value
 
     if stream:
         _stream_render(
-            caption_image(img, style=style, expects=expects_value, stream=True),
+            caption_image(node, style=style, expects=expects_value, stream=True),
             title="Caption",
             output_format=output_format,
             show_raw=show_raw,
@@ -693,7 +733,7 @@ def caption(
         )
         return
 
-    res = caption_image(img, style=style, expects=expects_value)
+    res = caption_image(node, style=style, expects=expects_value)
     _render_result(
         res,
         title="Caption",
@@ -717,7 +757,7 @@ def ocr(
         help="Output format (text or json).",
     ),
 ):
-    """Run OCR via the high-level helper."""
+    """Run OCR via the high-level helper. Image inputs only."""
 
     path = Path(image)
     if path.is_dir():
@@ -726,13 +766,13 @@ def ocr(
             command_name="ocr",
             stream=False,
             show_raw=show_raw,
-            runner=lambda data: ocr_image(data, prompt=prompt),
+            runner=lambda data: ocr_image(image_node(data), prompt=prompt),
             payload_factory=_ocr_payload,
         )
         return
 
-    img = _resolve_image(image)
-    res = ocr_image(img, prompt=prompt)
+    img_data = _resolve_media(image)
+    res = ocr_image(image_node(img_data), prompt=prompt)
     _render_result(
         res,
         title="OCR",
@@ -755,7 +795,7 @@ def detect(
     ),
     stream: bool = typer.Option(False, help="Stream incremental output."),
 ):
-    """Run detection via the high-level helper."""
+    """Run detection via the high-level helper. Image inputs only."""
 
     class_list = [c.strip() for c in classes.split(",")] if classes else None
     path = Path(image)
@@ -765,15 +805,16 @@ def detect(
             command_name="detect",
             stream=False,
             show_raw=show_raw,
-            runner=lambda data: detect_image(data, classes=class_list),
+            runner=lambda data: detect_image(image_node(data), classes=class_list),
             payload_factory=_detect_payload,
         )
         return
 
-    img = _resolve_image(image)
+    img_data = _resolve_media(image)
+    node = image_node(img_data)
     if stream:
         _stream_render(
-            detect_image(img, classes=class_list, stream=True),
+            detect_image(node, classes=class_list, stream=True),
             title="Detect",
             output_format=output_format,
             show_raw=show_raw,
@@ -781,7 +822,7 @@ def detect(
             expects="box",
         )
         return
-    res = detect_image(img, classes=class_list)
+    res = detect_image(node, classes=class_list)
     _render_result(
         res,
         title="Detect",
@@ -794,13 +835,13 @@ def detect(
 
 @app.command()
 def question(
-    image: str = typer.Argument(..., help="Image path or URL."),
-    prompt: str = typer.Argument(..., help="Question to answer about the image."),
+    media: str = typer.Argument(..., help="Image or video path or URL."),
+    prompt: str = typer.Argument(..., help="Question to answer about the media."),
     expects: ExpectationType = typer.Option(
         ExpectationType.TEXT,
         "--expects",
         case_sensitive=False,
-        help="Expected output structure (text, point, box, polygon, or think).",
+        help="Expected output structure (text, point, box, polygon, clip, or think).",
     ),
     stream: bool = typer.Option(False, help="Stream incremental output."),
     show_raw: bool = typer.Option(False, help="Display raw response JSON."),
@@ -812,22 +853,23 @@ def question(
         help="Output format (text or json).",
     ),
 ):
-    """Answer a question about an image."""
+    """Answer a question about an image or video."""
 
-    path = Path(image)
+    path = Path(media)
     if path.is_dir():
         raise typer.BadParameter("Directory mode is not supported for 'question'.")
 
     try:
-        img = _resolve_image(image)
+        media_data = _resolve_media(media)
     except ValueError as exc:
         raise typer.BadParameter(str(exc)) from exc
 
+    node = _make_media_node(media, media_data)
     expects_value = expects.value
 
     if stream:
         _stream_render(
-            question_image(img, prompt, expects=expects_value, stream=True),
+            question_image(node, prompt, expects=expects_value, stream=True),
             title="Question",
             output_format=output_format,
             show_raw=show_raw,
@@ -836,7 +878,7 @@ def question(
         )
         return
 
-    res = question_image(img, prompt, expects=expects_value)
+    res = question_image(node, prompt, expects=expects_value)
     show_points = expects in {
         ExpectationType.POINT,
         ExpectationType.BOX,

--- a/src/perceptron/cli.py
+++ b/src/perceptron/cli.py
@@ -41,7 +41,7 @@ _IMAGE_EXTENSIONS = {
     ".heif",
 }
 
-_VIDEO_EXTENSIONS = {".mp4"}
+_VIDEO_EXTENSIONS = {".mp4", ".webm"}
 
 _OUTPUT_FILENAMES = {
     "caption": "captions.json",

--- a/src/perceptron/client.py
+++ b/src/perceptron/client.py
@@ -506,11 +506,17 @@ _PROVIDER_CONFIG = {
         "auth_prefix": "Bearer ",
         "env_keys": ["PERCEPTRON_API_KEY"],
         "default_model": "isaac-0.1",
-        "supported_models": ["isaac-0.1", "isaac-0.2-1b", "isaac-0.2-2b-preview"],
+        "supported_models": [
+            "isaac-0.1",
+            "isaac-0.2-1b",
+            "isaac-0.2-2b-preview",
+            "isaac-0.3-max",
+        ],
         "models": {
             "isaac-0.1": {"reasoning": False, "skip_structured_hints": False, "focus": False},
             "isaac-0.2-1b": {"reasoning": True, "skip_structured_hints": False, "focus": True},
             "isaac-0.2-2b-preview": {"reasoning": True, "skip_structured_hints": False, "focus": True},
+            "isaac-0.3-max": {"reasoning": True, "skip_structured_hints": False, "focus": True},
         },
         "stream": True,
     },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -527,9 +527,14 @@ def test_stream_render_final_text_overrides_buffer(monkeypatch):
         "https://example.com/clip.mp4?token=abc",
         "https://example.com/clip.mp4#fragment",
         "CLIP.MP4",  # case-insensitive
+        "clip.webm",
+        "/local/path/clip.webm",
+        "https://example.com/clip.webm",
+        "https://example.com/clip.webm?token=abc",
+        "CLIP.WEBM",
     ],
 )
-def test_looks_like_video_recognizes_mp4(media):
+def test_looks_like_video_recognizes_video_extensions(media):
     assert _looks_like_video(media) is True
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,9 +8,14 @@ from perceptron.cli import (
     OutputFormat,
     _bucket_for_expects,
     _coerce_result_dict,
+    _describe_point,
+    _looks_like_video,
+    _make_media_node,
     _stream_render,
     app,
 )
+from perceptron.dsl.nodes import Image as ImageNode
+from perceptron.dsl.nodes import Video as VideoNode
 from perceptron.pointing.types import BoundingBox, Clip, ClipTimestamp, Polygon, SinglePoint
 
 
@@ -72,9 +77,10 @@ def test_caption_command_directory(monkeypatch, tmp_path):
     (tmp_path / "notes.txt").write_text("ignore me")
 
     def _fake_caption(data, **kwargs):
-        if data == b"image-one":
+        assert isinstance(data, ImageNode)
+        if data.obj == b"image-one":
             return _StubResult("caption-one")
-        if data == b"image-two":
+        if data.obj == b"image-two":
             return _StubResult("caption-two")
         raise AssertionError("unexpected payload")
 
@@ -104,9 +110,10 @@ def test_ocr_command_directory(monkeypatch, tmp_path):
     img2.write_bytes(b"image-two")
 
     def _fake_ocr(data, *, prompt=None):
-        if data == b"image-one":
+        assert isinstance(data, ImageNode)
+        if data.obj == b"image-one":
             return _StubResult("ocr-one")
-        if data == b"image-two":
+        if data.obj == b"image-two":
             return _StubResult("ocr-two")
         raise AssertionError("unexpected payload")
 
@@ -142,7 +149,8 @@ def test_detect_command_directory(monkeypatch, tmp_path):
 
     def _fake_detect(data, *, classes=None):
         assert classes == ["person"]
-        res = _StubResult("detected-one" if data == b"image-one" else "detected-two")
+        assert isinstance(data, ImageNode)
+        res = _StubResult("detected-one" if data.obj == b"image-one" else "detected-two")
         res.boxes = [
             BoundingBox(
                 top_left=SinglePoint(1, 2, mention="person"),
@@ -502,3 +510,108 @@ def test_stream_render_final_text_overrides_buffer(monkeypatch):
     )
 
     assert captured["payload"]["text"] == "authoritative"
+
+
+# ---------------------------------------------------------------------------
+# Media-aware CLI helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "media",
+    [
+        "clip.mp4",
+        "/local/path/clip.mp4",
+        "https://example.com/clip.mp4",
+        "https://example.com/clip.mp4?token=abc",
+        "https://example.com/clip.mp4#fragment",
+        "CLIP.MP4",  # case-insensitive
+    ],
+)
+def test_looks_like_video_recognizes_mp4(media):
+    assert _looks_like_video(media) is True
+
+
+@pytest.mark.parametrize(
+    "media",
+    [
+        "image.jpg",
+        "/local/path/image.png",
+        "https://example.com/image.webp",
+        "no-extension",
+    ],
+)
+def test_looks_like_video_rejects_non_video(media):
+    assert _looks_like_video(media) is False
+
+
+def test_make_media_node_wraps_video_for_mp4_url():
+    node = _make_media_node("https://example.com/clip.mp4", "https://example.com/clip.mp4")
+    assert isinstance(node, VideoNode)
+
+
+def test_make_media_node_wraps_image_for_png():
+    node = _make_media_node("https://example.com/img.png", "https://example.com/img.png")
+    assert isinstance(node, ImageNode)
+
+
+def test_question_command_passes_video_node_to_sdk(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _capture(media, prompt, **kwargs):
+        captured["media"] = media
+        captured["prompt"] = prompt
+        return _StubResult("ok")
+
+    monkeypatch.setattr("perceptron.cli.question_image", _capture)
+    result = runner.invoke(app, ["question", "https://example.com/clip.mp4", "What happens?"])
+    assert result.exit_code == 0
+    assert isinstance(captured["media"], VideoNode)
+
+
+def test_question_command_passes_image_node_to_sdk(monkeypatch):
+    captured: dict[str, object] = {}
+
+    def _capture(media, prompt, **kwargs):
+        captured["media"] = media
+        return _StubResult("ok")
+
+    monkeypatch.setattr("perceptron.cli.question_image", _capture)
+    result = runner.invoke(app, ["question", "https://example.com/img.png", "What is shown?"])
+    assert result.exit_code == 0
+    assert isinstance(captured["media"], ImageNode)
+
+
+def test_describe_point_renders_clip_moment():
+    kind, coords, mention = _describe_point(Clip(timestamp=ClipTimestamp(at=1.5), mention="intro"))
+    assert kind == "clip"
+    assert coords == "@1.50s"
+    assert mention == "intro"
+
+
+def test_describe_point_renders_clip_range():
+    kind, coords, mention = _describe_point(Clip(timestamp=ClipTimestamp(at=2.0, until=4.5), mention="hook"))
+    assert kind == "clip"
+    assert coords == "2.00s → 4.50s"
+    assert mention == "hook"
+
+
+def test_question_command_clip_text_renders_clips_table(monkeypatch):
+    res = _StubResult("found it")
+    res.clips = [Clip(timestamp=ClipTimestamp(at=3.0, until=5.0), mention="shot")]
+    monkeypatch.setattr("perceptron.cli.question_image", lambda *a, **k: res)
+    result = runner.invoke(
+        app,
+        [
+            "question",
+            "https://example.com/clip.mp4",
+            "When does the shot happen?",
+            "--expects",
+            "clip",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Clips" in result.stdout
+    assert "3.00s" in result.stdout
+    assert "5.00s" in result.stdout
+    assert "shot" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ from perceptron.cli import (
     _describe_point,
     _looks_like_video,
     _make_media_node,
+    _resolve_media,
     _stream_render,
     app,
 )
@@ -594,6 +595,18 @@ def test_describe_point_renders_clip_range():
     assert kind == "clip"
     assert coords == "2.00s → 4.50s"
     assert mention == "hook"
+
+
+def test_resolve_media_rejects_directory(tmp_path):
+    """_resolve_media raises ValueError when given a directory."""
+    with pytest.raises(ValueError, match="Expected media file"):
+        _resolve_media(str(tmp_path))
+
+
+def test_question_command_rejects_directory(tmp_path):
+    """The question CLI command bails when given a directory (BadParameter -> exit code 2)."""
+    result = runner.invoke(app, ["question", str(tmp_path), "What is shown?"])
+    assert result.exit_code == 2
 
 
 def test_question_command_clip_text_renders_clips_table(monkeypatch):

--- a/tests/test_prompt_profiles.py
+++ b/tests/test_prompt_profiles.py
@@ -41,6 +41,26 @@ def test_caption_defaults_to_isaac_prompt_on_fal():
     assert "Provide a concise, human-friendly caption for the upcoming image." in user_messages
 
 
+def test_select_model_accepts_isaac_0_3_max_for_perceptron():
+    perceptron_cfg = {"name": "perceptron", **_PROVIDER_CONFIG["perceptron"]}
+    resolved = _select_model(perceptron_cfg, "isaac-0.3-max")
+    assert resolved == "isaac-0.3-max"
+
+
+def test_select_model_rejects_isaac_0_3_max_for_fal():
+    fal_cfg = {"name": "fal", **_PROVIDER_CONFIG["fal"]}
+    with pytest.raises(BadRequestError):
+        _select_model(fal_cfg, "isaac-0.3-max")
+
+
+def test_isaac_0_3_max_models_entry_supports_reasoning_and_focus():
+    perceptron_cfg = _PROVIDER_CONFIG["perceptron"]
+    entry = perceptron_cfg["models"]["isaac-0.3-max"]
+    assert entry["reasoning"] is True
+    assert entry["focus"] is True
+    assert entry["skip_structured_hints"] is False
+
+
 def test_config_context_propagates_default_model():
     categories = ["plate/dish"]
     with cfg(api_key="test-key", provider="perceptron", model="isaac-0.2-2b-preview"):


### PR DESCRIPTION
## Summary
Closes the gaps left after Max's v0.3.0 SDK refactor (PRs #56–62). Three concrete fixes:

### 1. `client.py`: isaac-0.3-max in the allowlist
- Adds `isaac-0.3-max` to `_PROVIDER_CONFIG["perceptron"].supported_models` so the SDK actually accepts the new model in `question()`, `caption()`, `detect()`, `ocr()`. Modal serves it; the gateway accepts it; the Python SDK was rejecting pre-flight.
- Adds the per-model entry: `reasoning: True` (toggleable), `skip_structured_hints: False`, `focus: True` (Zoom internal tool).

### 2. `cli.py`: media-aware commands
After Max's #58 refactor, the SDK's `question/caption/detect/ocr` functions require a `MediaNode` (`image()` or `video()`), but the CLI was still passing raw bytes/URLs. The only reason CI didn't catch it is every existing CLI test monkeypatched the SDK call.
- Adds `_resolve_media`, `_looks_like_video`, `_make_media_node` helpers.
- Each CLI command now wraps its resolved input in `image()` or `video()` before calling the SDK.
- `question` and `caption` accept video paths/URLs (auto-detected by `.mp4` extension); `ocr` and `detect` stay image-only.

### 3. `cli.py`: clip rendering
- Adds a `Clip` case to `_describe_point` (renders `@1.50s` for moments and `2.00s → 4.50s` for ranges).
- Adds a clip-aware render path in `_render_result` so `--expects clip` produces a readable Clips table rather than a JSON dump.

## Tests
- 3 new allowlist tests: `isaac-0.3-max` accepted on perceptron, rejected on fal, per-model entry shape verified.
- 7 new CLI tests covering `_looks_like_video` extension/URL parsing, `_make_media_node` wrapping behavior, end-to-end `question` routing to `ImageNode` vs `VideoNode` based on input, and clip rendering in both moment and range forms.
- 3 pre-existing directory-mode tests updated to assert the runner now receives an `ImageNode` (with `.obj == bytes`) rather than raw bytes.

**All 283 tests pass.**

## Unblocks
- [`perceptron#63`](https://github.com/perceptron-ai-inc/perceptron/pull/63) — quickstart Q&A notebooks.
- [`perceptron#64`](https://github.com/perceptron-ai-inc/perceptron/pull/64) — video capability notebooks.
- All upcoming isaac-0.3-max cookbook recipes.
- The Mintlify Quickstart and capability pages that reference `isaac-0.3-max` end-to-end.

## Stale PRs to consider closing
- `#31` ArmenAg `[core] video support in DSL and transport layer` — superseded by Max's merged `#58`.
- `#23` AkshatSh `SDK: Reasoning Parser` — months old; reasoning now lands as `result.reasoning` per the v0.3 work.

## Test plan
- [x] Run `uv run --with pytest --with pytest-cov pytest --no-cov` and confirm 283 pass.
- [ ] After merge: re-run `tools/run_notebooks.py` against `perceptron#63` and `#64` with `PERCEPTRON_API_KEY` set; expect both to pass end-to-end.
- [ ] Manually exercise `perceptron question https://example.com/clip.mp4 "what happens" --expects clip` against a real key; confirm a Clips table renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)