### PR TITLE
Add Isaac 0.3 Max sibling notebooks for image capabilities

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -28,6 +28,21 @@ Hands-on quickstarts, capability recipes, and end-to-end tutorials for building 
 
 > **When to use `detect()` vs `@perceive`?** Use `detect()` for quick, single-shot helpers. Reach for `@perceive` when you want to embed custom prompts, streaming, or multi-step logic inside your own pipeline.
 
+### Isaac 0.3 Max sibling recipes
+
+The same capabilities, configured for the flagship `isaac-0.3-max` model and using the post-v0.3.0 SDK API. Image-only legacy recipes above remain valid for the 0.x family.
+
+| Notebook | Scenario | Colab |
+| --- | --- | --- |
+| [`isaac-0.3-max/image-qa`](recipes/capabilities/isaac-0.3-max/image-qa.ipynb) | Grounded Q&A with bounding-box citations on a studio scene. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb) |
+| [`isaac-0.3-max/image-captioning`](recipes/capabilities/isaac-0.3-max/image-captioning.ipynb) | Concise and detailed captions, optionally with grounded snippets. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb) |
+| [`isaac-0.3-max/object-detection`](recipes/capabilities/isaac-0.3-max/object-detection.ipynb) | PPE detection via the `@perceive` helper with `expects="box"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb) |
+| [`isaac-0.3-max/ocr`](recipes/capabilities/isaac-0.3-max/ocr.ipynb) | OCR with custom prompts targeting product labels. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb) |
+| [`isaac-0.3-max/in-context-learning-image`](recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb) | Single-image ICL: bootstrap an exemplar, apply to a new scene. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb) |
+| [`isaac-0.3-max/video-qa`](recipes/capabilities/isaac-0.3-max/video-qa.ipynb) | Long-form video Q&A with reasoning enabled (robot-assembly walkthrough). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-qa.ipynb) |
+| [`isaac-0.3-max/video-clipping`](recipes/capabilities/isaac-0.3-max/video-clipping.ipynb) | Temporal grounding: return start/end timestamps via `expects="clip"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-clipping.ipynb) |
+| [`isaac-0.3-max/in-context-learning-video`](recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb) | Multimodal ICL: example image + intent → query video → clip back. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb) |
+
 ---
 
 ## Tutorials

--- a/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb
@@ -46,11 +46,9 @@
    "cell_type": "code", "execution_count": null, "id": "icap-conf", "metadata": {}, "outputs": [],
    "source": [
     "import os\n",
-    "from pathlib import Path\n",
     "\n",
-    "from IPython.display import Image as IPyImage\n",
     "from IPython.display import display\n",
-    "from PIL import Image, ImageDraw, ImageFont\n",
+    "from PIL import Image as PILImage\n",
     "\n",
     "from perceptron import caption, configure, image\n",
     "\n",
@@ -65,8 +63,7 @@
     ")\n",
     "\n",
     "SUBURBAN_STREET = \"suburban_street.webp\"\n",
-    "SOLAR_ARRAY = \"solar_array.webp\"\n",
-    "SOLAR_ANNOTATED = Path(\"solar_array_annotated.png\")"
+    "SOLAR_ARRAY = \"solar_array.webp\""
    ]
   },
   {
@@ -76,55 +73,25 @@
   {
    "cell_type": "code", "execution_count": null, "id": "icap-quick", "metadata": {}, "outputs": [],
    "source": [
-    "display(IPyImage(filename=SUBURBAN_STREET))\n",
+    "display(PILImage.open(SUBURBAN_STREET))\n",
     "street_caption = caption(image(str(SUBURBAN_STREET)), style=\"concise\", expects=\"text\")\n",
     "print(street_caption.text)"
    ]
   },
   {
    "cell_type": "markdown", "id": "icap-grndhdr", "metadata": {},
-   "source": ["## Request grounded details\nSwitch styles and ask for bounding boxes so downstream tooling can highlight each part of the caption."]
+   "source": ["## Request a detailed caption\nSwitch styles to get a richer narrative description with more nuance and context."]
   },
   {
    "cell_type": "code", "execution_count": null, "id": "icap-grnd", "metadata": {}, "outputs": [],
    "source": [
+    "display(PILImage.open(SOLAR_ARRAY))\n",
     "solar_caption = caption(\n",
     "    image(str(SOLAR_ARRAY)),\n",
     "    style=\"detailed\",\n",
-    "    expects=\"box\",\n",
+    "    expects=\"text\",\n",
     ")\n",
-    "print(solar_caption.text)\n",
-    "boxes = solar_caption.boxes or []\n",
-    "print(f\"Returned {len(boxes)} grounded snippets\")"
-   ]
-  },
-  {
-   "cell_type": "code", "execution_count": null, "id": "icap-render", "metadata": {}, "outputs": [],
-   "source": [
-    "img = Image.open(SOLAR_ARRAY).convert(\"RGB\")\n",
-    "draw = ImageDraw.Draw(img)\n",
-    "try:\n",
-    "    font = ImageFont.truetype(\"arial.ttf\", size=20)\n",
-    "except OSError:\n",
-    "    font = ImageFont.load_default()\n",
-    "\n",
-    "if boxes:\n",
-    "\n",
-    "    def to_px(point):\n",
-    "        return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
-    "\n",
-    "    for idx, box in enumerate(boxes):\n",
-    "        top_left = to_px(box.top_left)\n",
-    "        bottom_right = to_px(box.bottom_right)\n",
-    "        draw.rectangle([top_left, bottom_right], outline=\"orange\", width=3)\n",
-    "        label = box.mention or f\"snippet {idx + 1}\"\n",
-    "        draw.text((top_left[0], max(top_left[1] - 18, 0)), label, fill=\"orange\", font=font)\n",
-    "else:\n",
-    "    print(\"No grounded regions returned; set expects='box' to request them.\")\n",
-    "\n",
-    "img.save(SOLAR_ANNOTATED)\n",
-    "display(IPyImage(filename=str(SOLAR_ANNOTATED)))\n",
-    "print(f\"Saved annotated caption overlay to {SOLAR_ANNOTATED}\")"
+    "print(solar_caption.text)"
    ]
   },
   {

--- a/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb
@@ -1,0 +1,146 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "id": "icap-cprt", "metadata": {}, "source": ["##### Copyright 2025 Perceptron AI."]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "icap-lic", "metadata": {}, "outputs": [],
+   "source": [
+    "# Licensed under the MIT License (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://opensource.org/licenses/MIT\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icap-title", "metadata": {},
+   "source": [
+    "# Capability — Image Captioning (Isaac 0.3 Max)\n",
+    "Generate concise or rich descriptions for any scene, optionally returning grounded regions alongside the text.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb)"
+   ]
+  },
+  {"cell_type": "markdown", "id": "icap-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
+  {"cell_type": "code", "execution_count": null, "id": "icap-install", "metadata": {}, "outputs": [], "source": ["%pip install --upgrade perceptron --quiet"]},
+  {"cell_type": "markdown", "id": "icap-dlhdr", "metadata": {}, "source": ["## Download assets"]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "icap-dl", "metadata": {}, "outputs": [],
+   "source": [
+    "ASSET_BASE = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets\"\n",
+    "\n",
+    "!curl -so suburban_street.webp {ASSET_BASE}/capabilities/caption/suburban_street.webp\n",
+    "!curl -so solar_array.webp {ASSET_BASE}/capabilities/caption/solar_array.webp"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icap-confhdr", "metadata": {},
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icap-conf", "metadata": {}, "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from IPython.display import Image as IPyImage\n",
+    "from IPython.display import display\n",
+    "from PIL import Image, ImageDraw, ImageFont\n",
+    "\n",
+    "from perceptron import caption, configure, image\n",
+    "\n",
+    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
+    "if not api_key or api_key.startswith(\"<\"):\n",
+    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
+    "\n",
+    "configure(\n",
+    "    provider=\"perceptron\",\n",
+    "    model=\"isaac-0.3-max\",\n",
+    "    api_key=api_key,\n",
+    ")\n",
+    "\n",
+    "SUBURBAN_STREET = \"suburban_street.webp\"\n",
+    "SOLAR_ARRAY = \"solar_array.webp\"\n",
+    "SOLAR_ANNOTATED = Path(\"solar_array_annotated.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icap-quickhdr", "metadata": {},
+   "source": ["## Describe a suburban street\nThe simplest call requests a concise caption and returns plain text."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icap-quick", "metadata": {}, "outputs": [],
+   "source": [
+    "display(IPyImage(filename=SUBURBAN_STREET))\n",
+    "street_caption = caption(image(str(SUBURBAN_STREET)), style=\"concise\", expects=\"text\")\n",
+    "print(street_caption.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icap-grndhdr", "metadata": {},
+   "source": ["## Request grounded details\nSwitch styles and ask for bounding boxes so downstream tooling can highlight each part of the caption."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icap-grnd", "metadata": {}, "outputs": [],
+   "source": [
+    "solar_caption = caption(\n",
+    "    image(str(SOLAR_ARRAY)),\n",
+    "    style=\"detailed\",\n",
+    "    expects=\"box\",\n",
+    ")\n",
+    "print(solar_caption.text)\n",
+    "boxes = solar_caption.boxes or []\n",
+    "print(f\"Returned {len(boxes)} grounded snippets\")"
+   ]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icap-render", "metadata": {}, "outputs": [],
+   "source": [
+    "img = Image.open(SOLAR_ARRAY).convert(\"RGB\")\n",
+    "draw = ImageDraw.Draw(img)\n",
+    "try:\n",
+    "    font = ImageFont.truetype(\"arial.ttf\", size=20)\n",
+    "except OSError:\n",
+    "    font = ImageFont.load_default()\n",
+    "\n",
+    "if boxes:\n",
+    "\n",
+    "    def to_px(point):\n",
+    "        return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
+    "\n",
+    "    for idx, box in enumerate(boxes):\n",
+    "        top_left = to_px(box.top_left)\n",
+    "        bottom_right = to_px(box.bottom_right)\n",
+    "        draw.rectangle([top_left, bottom_right], outline=\"orange\", width=3)\n",
+    "        label = box.mention or f\"snippet {idx + 1}\"\n",
+    "        draw.text((top_left[0], max(top_left[1] - 18, 0)), label, fill=\"orange\", font=font)\n",
+    "else:\n",
+    "    print(\"No grounded regions returned; set expects='box' to request them.\")\n",
+    "\n",
+    "img.save(SOLAR_ANNOTATED)\n",
+    "display(IPyImage(filename=str(SOLAR_ANNOTATED)))\n",
+    "print(f\"Saved annotated caption overlay to {SOLAR_ANNOTATED}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icap-next", "metadata": {},
+   "source": [
+    "## Conclusion & next steps\n",
+    "- Adjust the `style` argument (`concise`, `detailed`) to match your UX.\n",
+    "- Keep `expects=\"text\"` for pure narrative outputs or request grounding via `expects=\"box\"` / `\"point\"`.\n",
+    "- Pass `reasoning=True` for richer descriptions of complex scenes."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "perceptron-uv"},
+  "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb
@@ -1,0 +1,133 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "id": "iqa-cprt", "metadata": {}, "source": ["##### Copyright 2025 Perceptron AI."]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "iqa-lic", "metadata": {}, "outputs": [],
+   "source": [
+    "# Licensed under the MIT License (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://opensource.org/licenses/MIT\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "iqa-title", "metadata": {},
+   "source": [
+    "# Capability — Image Q&A (Isaac 0.3 Max)\n",
+    "Ask natural-language questions about a scene and receive answers plus bounding boxes for supporting evidence.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "iqa-installhdr", "metadata": {},
+   "source": ["## Install dependencies\nInstall the SDK and Pillow for inline previews."]
+  },
+  {"cell_type": "code", "execution_count": null, "id": "iqa-install", "metadata": {}, "outputs": [], "source": ["%pip install --upgrade perceptron --quiet"]},
+  {"cell_type": "markdown", "id": "iqa-dlhdr", "metadata": {}, "source": ["## Download assets"]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "iqa-dl", "metadata": {}, "outputs": [],
+   "source": [
+    "IMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp\"\n",
+    "\n",
+    "!curl -so studio_scene.webp {IMAGE_URL}"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "iqa-confhdr", "metadata": {},
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "iqa-conf", "metadata": {}, "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from IPython.display import Image as IPyImage\n",
+    "from IPython.display import display\n",
+    "from PIL import Image, ImageDraw\n",
+    "\n",
+    "from perceptron import configure, image, question\n",
+    "\n",
+    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
+    "if not api_key or api_key.startswith(\"<\"):\n",
+    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
+    "\n",
+    "configure(\n",
+    "    provider=\"perceptron\",\n",
+    "    model=\"isaac-0.3-max\",\n",
+    "    api_key=api_key,\n",
+    ")\n",
+    "\n",
+    "SCENE_PATH = \"studio_scene.webp\"\n",
+    "ANNOTATED_PATH = Path(\"studio_scene_annotated.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "iqa-askhdr", "metadata": {},
+   "source": ["## Ask a grounded question\nRequest boxed evidence so the model cites the regions that justify its answer."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "iqa-ask", "metadata": {}, "outputs": [],
+   "source": [
+    "QUESTION = \"What is the focal point of this scene? Be concise.\"\n",
+    "qa_result = question(image(str(SCENE_PATH)), QUESTION, expects=\"box\")\n",
+    "print(qa_result.text)\n",
+    "boxes = qa_result.boxes or []\n",
+    "print(f\"Returned {len(boxes)} supporting regions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "iqa-rendhdr", "metadata": {},
+   "source": ["## Visualize supporting evidence\nConvert the normalized boxes to pixels and render the overlay."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "iqa-render", "metadata": {}, "outputs": [],
+   "source": [
+    "img = Image.open(SCENE_PATH).convert(\"RGB\")\n",
+    "draw = ImageDraw.Draw(img)\n",
+    "\n",
+    "if boxes:\n",
+    "\n",
+    "    def to_px(point):\n",
+    "        return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
+    "\n",
+    "    for box in boxes:\n",
+    "        top_left = to_px(box.top_left)\n",
+    "        bottom_right = to_px(box.bottom_right)\n",
+    "        draw.rectangle([top_left, bottom_right], outline=\"crimson\", width=3)\n",
+    "        label = box.mention or \"reference\"\n",
+    "        draw.text((top_left[0], max(top_left[1] - 18, 0)), label, fill=\"crimson\")\n",
+    "else:\n",
+    "    print(\"No regions returned; adjust the question or expects parameter.\")\n",
+    "\n",
+    "img.save(ANNOTATED_PATH)\n",
+    "display(IPyImage(filename=str(ANNOTATED_PATH)))\n",
+    "print(f\"Saved grounded answer to {ANNOTATED_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "iqa-next", "metadata": {},
+   "source": [
+    "## Conclusion & next steps\n",
+    "- Tune `QUESTION` toward inspections, instructions, or policy compliance checks.\n",
+    "- Swap `expects` to `\"text\"` for free-form answers or keep `\"box\"` / `\"point\"` for grounded citations.\n",
+    "- Pass `reasoning=True` when the answer benefits from deeper analysis.\n",
+    "- For video Q&A, see the [Video Q&A](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-qa.ipynb) notebook."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "perceptron-uv"},
+  "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb
@@ -50,7 +50,6 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "from IPython.display import Image as IPyImage\n",
     "from IPython.display import display\n",
     "from PIL import Image, ImageDraw\n",
     "\n",
@@ -77,7 +76,8 @@
   {
    "cell_type": "code", "execution_count": null, "id": "iqa-ask", "metadata": {}, "outputs": [],
    "source": [
-    "QUESTION = \"What is the focal point of this scene? Be concise.\"\n",
+    "display(Image.open(SCENE_PATH))\n",
+    "QUESTION = \"What is the single focal point of this scene? Pick just one and box only that element.\"\n",
     "qa_result = question(image(str(SCENE_PATH)), QUESTION, expects=\"box\")\n",
     "print(qa_result.text)\n",
     "boxes = qa_result.boxes or []\n",
@@ -109,7 +109,7 @@
     "    print(\"No regions returned; adjust the question or expects parameter.\")\n",
     "\n",
     "img.save(ANNOTATED_PATH)\n",
-    "display(IPyImage(filename=str(ANNOTATED_PATH)))\n",
+    "display(img)\n",
     "print(f\"Saved grounded answer to {ANNOTATED_PATH}\")"
    ]
   },

--- a/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb
@@ -1,0 +1,182 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "id": "icli-cprt", "metadata": {}, "source": ["##### Copyright 2025 Perceptron AI."]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "icli-lic", "metadata": {}, "outputs": [],
+   "source": [
+    "# Licensed under the MIT License (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://opensource.org/licenses/MIT\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icli-title", "metadata": {},
+   "source": [
+    "# Capability — Single-Image In-Context Learning (Isaac 0.3 Max)\n",
+    "Guide the model with one exemplar image before detecting the same object in a different scene.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb)"
+   ]
+  },
+  {"cell_type": "markdown", "id": "icli-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
+  {"cell_type": "code", "execution_count": null, "id": "icli-install", "metadata": {}, "outputs": [], "source": ["%pip install --upgrade perceptron --quiet"]},
+  {"cell_type": "markdown", "id": "icli-dlhdr", "metadata": {}, "source": ["## Download assets"]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "icli-dl", "metadata": {}, "outputs": [],
+   "source": [
+    "ASSET_BASE = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets\"\n",
+    "\n",
+    "!curl -so cake_mixer_example.webp {ASSET_BASE}/in-context-learning/single/cake_mixer_example.webp\n",
+    "!curl -so find_kitchen_item.webp {ASSET_BASE}/in-context-learning/single/find_kitchen_item.webp"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icli-confhdr", "metadata": {},
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icli-conf", "metadata": {}, "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from IPython.display import Image as IPyImage\n",
+    "from IPython.display import display\n",
+    "from PIL import Image, ImageDraw, ImageFont\n",
+    "\n",
+    "from perceptron import annotate_image, bbox, configure, detect, image\n",
+    "\n",
+    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
+    "if not api_key or api_key.startswith(\"<\"):\n",
+    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
+    "\n",
+    "configure(\n",
+    "    provider=\"perceptron\",\n",
+    "    model=\"isaac-0.3-max\",\n",
+    "    api_key=api_key,\n",
+    ")\n",
+    "\n",
+    "EXAMPLE_IMAGE = \"cake_mixer_example.webp\"\n",
+    "TARGET_IMAGE = \"find_kitchen_item.webp\"\n",
+    "ANNOTATED_PATH = Path(\"find_kitchen_item_annotated.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icli-bootstraphdr", "metadata": {},
+   "source": ["## Bootstrap the exemplar box\nRun one detection pass on the exemplar image so we can feed a precise bounding box back as context."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icli-bootstrap", "metadata": {}, "outputs": [],
+   "source": [
+    "bootstrap = detect(\n",
+    "    image(str(EXAMPLE_IMAGE)),\n",
+    "    classes=[\"objectCategory1\"],\n",
+    "    max_outputs=1,\n",
+    ")\n",
+    "if not bootstrap.boxes:\n",
+    "    raise RuntimeError(\"Detect returned no boxes for the exemplar. Adjust the label or image.\")\n",
+    "\n",
+    "first_box = bootstrap.boxes[0]\n",
+    "example_shot = annotate_image(\n",
+    "    str(EXAMPLE_IMAGE),\n",
+    "    {\n",
+    "        \"objectCategory1\": [\n",
+    "            bbox(\n",
+    "                int(first_box.top_left.x),\n",
+    "                int(first_box.top_left.y),\n",
+    "                int(first_box.bottom_right.x),\n",
+    "                int(first_box.bottom_right.y),\n",
+    "                mention=\"objectCategory1\",\n",
+    "            )\n",
+    "        ]\n",
+    "    },\n",
+    ")\n",
+    "collections = example_shot.get(\"collections\") or []\n",
+    "boxes = example_shot.get(\"boxes\") or []\n",
+    "placeholder = \"objectCategory1\"\n",
+    "if collections:\n",
+    "    exemplar_annotation = collections[0]\n",
+    "elif boxes:\n",
+    "    exemplar_annotation = boxes[0]\n",
+    "else:\n",
+    "    raise RuntimeError(\"annotate_image returned no collections or boxes; check the exemplar annotations.\")\n",
+    "print(\"Prepared exemplar guidance with\", getattr(exemplar_annotation, \"mention\", placeholder) or placeholder)"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icli-detecthdr", "metadata": {},
+   "source": ["## Detect the same object in a new scene\nPass the exemplar annotation back to `detect` via the `examples` argument to nudge the model toward consistent grounding."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icli-detect", "metadata": {}, "outputs": [],
+   "source": [
+    "result = detect(\n",
+    "    image(str(TARGET_IMAGE)),\n",
+    "    classes=[\"objectCategory1\"],\n",
+    "    examples=[example_shot],\n",
+    ")\n",
+    "\n",
+    "print(result.text)\n",
+    "boxes = result.boxes or []\n",
+    "print(f\"Returned {len(boxes)} grounded regions\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icli-rendhdr", "metadata": {},
+   "source": ["## Render the grounded output\nOverlay the predicted boxes on the target scene and preview the saved PNG inline."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "icli-render", "metadata": {}, "outputs": [],
+   "source": [
+    "img = Image.open(TARGET_IMAGE).convert(\"RGB\")\n",
+    "draw = ImageDraw.Draw(img)\n",
+    "try:\n",
+    "    font = ImageFont.truetype(\"arial.ttf\", size=20)\n",
+    "except OSError:\n",
+    "    font = ImageFont.load_default()\n",
+    "\n",
+    "if boxes:\n",
+    "\n",
+    "    def to_px(point):\n",
+    "        return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
+    "\n",
+    "    for box in boxes:\n",
+    "        top_left = to_px(box.top_left)\n",
+    "        bottom_right = to_px(box.bottom_right)\n",
+    "        draw.rectangle([top_left, bottom_right], outline=\"lime\", width=3)\n",
+    "        label = box.mention or getattr(box, \"label\", None) or \"objectCategory1\"\n",
+    "        text_position = (top_left[0], max(top_left[1] - 20, 0))\n",
+    "        draw.text(text_position, label, fill=\"lime\", font=font)\n",
+    "else:\n",
+    "    print(\"No boxes returned; adjust the exemplar or label and rerun.\")\n",
+    "\n",
+    "img.save(ANNOTATED_PATH)\n",
+    "display(IPyImage(filename=str(ANNOTATED_PATH)))\n",
+    "print(f\"Saved annotated target to {ANNOTATED_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "icli-next", "metadata": {},
+   "source": [
+    "## Conclusion & next steps\n",
+    "- Swap in different exemplar / target pairs to explore other categories.\n",
+    "- Add more than one exemplar by appending to the `examples` list for tougher distinctions.\n",
+    "- For an open-ended (non-detection) ICL flow on a video, see [In-context learning (Video)](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "perceptron-uv"},
+  "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb
@@ -48,7 +48,6 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "from IPython.display import Image as IPyImage\n",
     "from IPython.display import display\n",
     "from PIL import Image, ImageDraw, ImageFont\n",
     "\n",
@@ -76,6 +75,7 @@
   {
    "cell_type": "code", "execution_count": null, "id": "icli-bootstrap", "metadata": {}, "outputs": [],
    "source": [
+    "display(Image.open(EXAMPLE_IMAGE))\n",
     "bootstrap = detect(\n",
     "    image(str(EXAMPLE_IMAGE)),\n",
     "    classes=[\"objectCategory1\"],\n",
@@ -118,6 +118,7 @@
   {
    "cell_type": "code", "execution_count": null, "id": "icli-detect", "metadata": {}, "outputs": [],
    "source": [
+    "display(Image.open(TARGET_IMAGE))\n",
     "result = detect(\n",
     "    image(str(TARGET_IMAGE)),\n",
     "    classes=[\"objectCategory1\"],\n",
@@ -159,7 +160,7 @@
     "    print(\"No boxes returned; adjust the exemplar or label and rerun.\")\n",
     "\n",
     "img.save(ANNOTATED_PATH)\n",
-    "display(IPyImage(filename=str(ANNOTATED_PATH)))\n",
+    "display(img)\n",
     "print(f\"Saved annotated target to {ANNOTATED_PATH}\")"
    ]
   },

--- a/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb
@@ -47,7 +47,6 @@
     "import os\n",
     "from pathlib import Path\n",
     "\n",
-    "from IPython.display import Image as IPyImage\n",
     "from IPython.display import display\n",
     "from PIL import Image, ImageDraw\n",
     "\n",
@@ -82,8 +81,9 @@
     "    frame = image(frame_path)\n",
     "    classes_text = \", \".join(TARGET_CLASSES)\n",
     "    prompt = text(\n",
-    "        \"Find every worker wearing PPE. Focus on helmets and high-visibility vests. \"\n",
-    "        \"Return one bounding box per instance and include the item name in the mention attribute.\"\n",
+    "        f\"Detect each individual instance of these items: {classes_text}. \"\n",
+    "        f\"Return one bounding box per item (not per person). \"\n",
+    "        f\"Set the mention attribute to the matching class name from this list.\"\n",
     "    )\n",
     "    return frame + prompt"
    ]
@@ -95,6 +95,7 @@
   {
    "cell_type": "code", "execution_count": null, "id": "od-run", "metadata": {}, "outputs": [],
    "source": [
+    "display(Image.open(SCENE_PATH))\n",
     "detection = detect_ppe(str(SCENE_PATH))\n",
     "print(detection.text)\n",
     "boxes = detection.boxes or []\n",
@@ -123,7 +124,7 @@
     "    draw.text(top_left, box.mention or \"ppe\", fill=\"dodgerblue\")\n",
     "\n",
     "img.save(ANNOTATED_PATH)\n",
-    "display(IPyImage(filename=str(ANNOTATED_PATH)))\n",
+    "display(img)\n",
     "print(f\"Saved annotated output to {ANNOTATED_PATH}\")"
    ]
   },

--- a/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb
@@ -1,0 +1,147 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "id": "od-cprt", "metadata": {}, "source": ["##### Copyright 2025 Perceptron AI."]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "od-lic", "metadata": {}, "outputs": [],
+   "source": [
+    "# Licensed under the MIT License (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://opensource.org/licenses/MIT\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "od-title", "metadata": {},
+   "source": [
+    "# Capability — PPE Detection (Isaac 0.3 Max)\n",
+    "Locate protective equipment on an assembly line and highlight every instance with normalized Perceptron geometry.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb)"
+   ]
+  },
+  {"cell_type": "markdown", "id": "od-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
+  {"cell_type": "code", "execution_count": null, "id": "od-install", "metadata": {}, "outputs": [], "source": ["%pip install --upgrade perceptron --quiet"]},
+  {"cell_type": "markdown", "id": "od-dlhdr", "metadata": {}, "source": ["## Download assets"]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "od-dl", "metadata": {}, "outputs": [],
+   "source": [
+    "IMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/detection/ppe_line.webp\"\n",
+    "\n",
+    "!curl -so ppe_line.webp {IMAGE_URL}"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "od-confhdr", "metadata": {},
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "od-conf", "metadata": {}, "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from IPython.display import Image as IPyImage\n",
+    "from IPython.display import display\n",
+    "from PIL import Image, ImageDraw\n",
+    "\n",
+    "from perceptron import configure, image, perceive, text\n",
+    "\n",
+    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
+    "if not api_key or api_key.startswith(\"<\"):\n",
+    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
+    "\n",
+    "configure(\n",
+    "    provider=\"perceptron\",\n",
+    "    model=\"isaac-0.3-max\",\n",
+    "    api_key=api_key,\n",
+    ")\n",
+    "\n",
+    "SCENE_PATH = \"ppe_line.webp\"\n",
+    "ANNOTATED_PATH = Path(\"ppe_line_annotated.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "od-helperhdr", "metadata": {},
+   "source": ["## Build a detection helper\nUse the `@perceive` decorator with `expects=\"box\"` so each detection returns normalized bounding boxes."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "od-helper", "metadata": {}, "outputs": [],
+   "source": [
+    "TARGET_CLASSES = [\"safety helmet\", \"safety vest\"]\n",
+    "\n",
+    "\n",
+    "@perceive(expects=\"box\", allow_multiple=True)\n",
+    "def detect_ppe(frame_path):\n",
+    "    frame = image(frame_path)\n",
+    "    classes_text = \", \".join(TARGET_CLASSES)\n",
+    "    prompt = text(\n",
+    "        \"Find every worker wearing PPE. Focus on helmets and high-visibility vests. \"\n",
+    "        \"Return one bounding box per instance and include the item name in the mention attribute.\"\n",
+    "    )\n",
+    "    return frame + prompt"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "od-runhdr", "metadata": {},
+   "source": ["## Run the detection request\nInvoke the helper on the PPE line image to retrieve grounded regions."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "od-run", "metadata": {}, "outputs": [],
+   "source": [
+    "detection = detect_ppe(str(SCENE_PATH))\n",
+    "print(detection.text)\n",
+    "boxes = detection.boxes or []\n",
+    "print(f\"Returned {len(boxes)} boxes\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "od-rendhdr", "metadata": {},
+   "source": ["## Render grounded results\nConvert the normalized coordinates to pixels and overlay them for quick inspection."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "od-render", "metadata": {}, "outputs": [],
+   "source": [
+    "img = Image.open(SCENE_PATH).convert(\"RGB\")\n",
+    "draw = ImageDraw.Draw(img)\n",
+    "\n",
+    "\n",
+    "def to_px(point):\n",
+    "    return point.x / 1000 * img.width, point.y / 1000 * img.height\n",
+    "\n",
+    "\n",
+    "for box in boxes:\n",
+    "    top_left = to_px(box.top_left)\n",
+    "    bottom_right = to_px(box.bottom_right)\n",
+    "    draw.rectangle([top_left, bottom_right], outline=\"dodgerblue\", width=3)\n",
+    "    draw.text(top_left, box.mention or \"ppe\", fill=\"dodgerblue\")\n",
+    "\n",
+    "img.save(ANNOTATED_PATH)\n",
+    "display(IPyImage(filename=str(ANNOTATED_PATH)))\n",
+    "print(f\"Saved annotated output to {ANNOTATED_PATH}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "od-next", "metadata": {},
+   "source": [
+    "## Conclusion & next steps\n",
+    "- Adjust `TARGET_CLASSES` and the prompt to fit your environment.\n",
+    "- Enable `stream=True` inside `@perceive` for incremental detections.\n",
+    "- Add exemplar shots (see the [in-context learning recipe](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb)) when classes are ambiguous.\n",
+    "- Pass `reasoning=True` for harder detection tasks."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "perceptron-uv"},
+  "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb
@@ -46,8 +46,8 @@
    "source": [
     "import os\n",
     "\n",
-    "from IPython.display import Image as IPyImage\n",
     "from IPython.display import display\n",
+    "from PIL import Image as PILImage\n",
     "\n",
     "from perceptron import configure, image, ocr\n",
     "\n",
@@ -62,7 +62,7 @@
     ")\n",
     "\n",
     "LABELS = \"grocery_labels.webp\"\n",
-    "OCR_PROMPT = \"Extract each produce label along with its listed price.\""
+    "OCR_PROMPT = \"Extract all price tags.\""
    ]
   },
   {
@@ -72,7 +72,7 @@
   {
    "cell_type": "code", "execution_count": null, "id": "ocr-run", "metadata": {}, "outputs": [],
    "source": [
-    "display(IPyImage(filename=LABELS))\n",
+    "display(PILImage.open(LABELS))\n",
     "ocr_result = ocr(image(str(LABELS)), prompt=OCR_PROMPT)\n",
     "print(ocr_result.text)"
    ]

--- a/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb
+++ b/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {"cell_type": "markdown", "id": "ocr-cprt", "metadata": {}, "source": ["##### Copyright 2025 Perceptron AI."]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "ocr-lic", "metadata": {}, "outputs": [],
+   "source": [
+    "# Licensed under the MIT License (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "# https://opensource.org/licenses/MIT\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "ocr-title", "metadata": {},
+   "source": [
+    "# Capability — OCR with Custom Prompts (Isaac 0.3 Max)\n",
+    "Extract structured text from product imagery while tailoring the prompt to your downstream format.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb)"
+   ]
+  },
+  {"cell_type": "markdown", "id": "ocr-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
+  {"cell_type": "code", "execution_count": null, "id": "ocr-install", "metadata": {}, "outputs": [], "source": ["%pip install --upgrade perceptron --quiet"]},
+  {"cell_type": "markdown", "id": "ocr-dlhdr", "metadata": {}, "source": ["## Download assets"]},
+  {
+   "cell_type": "code", "execution_count": null, "id": "ocr-dl", "metadata": {}, "outputs": [],
+   "source": [
+    "IMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/ocr/grocery_labels.webp\"\n",
+    "\n",
+    "!curl -so grocery_labels.webp {IMAGE_URL}"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "ocr-confhdr", "metadata": {},
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "ocr-conf", "metadata": {}, "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from IPython.display import Image as IPyImage\n",
+    "from IPython.display import display\n",
+    "\n",
+    "from perceptron import configure, image, ocr\n",
+    "\n",
+    "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
+    "if not api_key or api_key.startswith(\"<\"):\n",
+    "    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n",
+    "\n",
+    "configure(\n",
+    "    provider=\"perceptron\",\n",
+    "    model=\"isaac-0.3-max\",\n",
+    "    api_key=api_key,\n",
+    ")\n",
+    "\n",
+    "LABELS = \"grocery_labels.webp\"\n",
+    "OCR_PROMPT = \"Extract each produce label along with its listed price.\""
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "ocr-runhdr", "metadata": {},
+   "source": ["## Extract labels from a single frame\nPreview the grocery case, run OCR with a custom prompt, and inspect the response."]
+  },
+  {
+   "cell_type": "code", "execution_count": null, "id": "ocr-run", "metadata": {}, "outputs": [],
+   "source": [
+    "display(IPyImage(filename=LABELS))\n",
+    "ocr_result = ocr(image(str(LABELS)), prompt=OCR_PROMPT)\n",
+    "print(ocr_result.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown", "id": "ocr-next", "metadata": {},
+   "source": [
+    "## Conclusion & next steps\n",
+    "- Tune `OCR_PROMPT` toward your schema (SKUs, serial numbers, line items, etc.).\n",
+    "- Iterate over folders to transcribe production frames in batch.\n",
+    "- Pair OCR output with `detect` / `question` helpers for richer workflows.\n",
+    "- Reach for `ocr_html` or `ocr_markdown` when you want structured layout output."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "perceptron-uv"},
+  "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.12.12"}
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
Five new sibling notebooks under `cookbook/recipes/capabilities/isaac-0.3-max/` that mirror the existing isaac-0.x capability recipes but configured for the new flagship model:

| New notebook | Mirrors |
|---|---|
| `isaac-0.3-max/image-qa.ipynb` | `visual-qa/visual-qa.ipynb` |
| `isaac-0.3-max/image-captioning.ipynb` | `captioning/captioning.ipynb` |
| `isaac-0.3-max/object-detection.ipynb` | `object-detection/object-detection.ipynb` |
| `isaac-0.3-max/ocr.ipynb` | `ocr/ocr.ipynb` |
| `isaac-0.3-max/in-context-learning-image.ipynb` | `in-context-learning/in-context-learning.ipynb` |

Reuses every existing shared asset under `cookbook/_shared/assets/` — nothing new to upload. Each notebook configures `model="isaac-0.3-max"`, uses the post-#58 SDK API (positional `MediaNode`; `.boxes/.points/.polygons/.clips`), and cross-links to the matching sibling video notebooks where relevant.

## Why
The legacy isaac-0.2 capability recipes are preserved untouched so existing Colab links and tutorials keep working. Anything under `cookbook/recipes/capabilities/isaac-0.3-max/` is the new flagship; future model launches can drop a `cookbook/recipes/capabilities/isaac-0.4-*/` sibling next to it.

## Pairs with
- **`perceptron#65`** (SDK v0.3.1 polish) — must merge first to add `isaac-0.3-max` to the SDK allowlist; otherwise these notebooks raise `BadRequestError`.
- Forthcoming **mintlify_docs** PR rewriting `capabilities/image-qa.mdx`, `image-captioning.mdx`, `object-detection.mdx`, `ocr.mdx`, `in-context-learning-image.mdx` to point Colab badges at these notebooks instead of the legacy ones.

## Test plan
- [x] Once `perceptron#65` lands, run `uv run python tools/run_notebooks.py --timeout 900` with a valid `PERCEPTRON_API_KEY`. Expect all five new notebooks to pass alongside the legacy isaac-0.2 ones.
- [ ] Open each in Colab post-merge; confirm asset URLs resolve from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)