### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "perceptron"
-version = "0.3.0"
+version = "0.3.1"
 description = "Perceptron multimodal SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/perceptron/__init__.py
+++ b/src/perceptron/__init__.py
@@ -13,7 +13,7 @@ network access. Transport and streaming are added in later phases.
 
 import importlib
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .annotations import annotate_image
 from .client import (


### PR DESCRIPTION
## Summary
Two-line version bump: `pyproject.toml` and `src/perceptron/__init__.py` from `0.3.0` → `0.3.1`.

## Why now
Releases the SDK polish landed in [#65](https://github.com/perceptron-ai-inc/perceptron/pull/65) and the Qwen3VL removal from [#67](https://github.com/perceptron-ai-inc/perceptron/pull/67) to PyPI:

- `isaac-0.3-max` added to `_PROVIDER_CONFIG["perceptron"].supported_models` — calls to the new flagship model from the SDK.
- CLI made media-aware (auto-detects `.mp4` and `.webm` and routes through `video()`).
- CLI clip-output rendering as a Rich "Clips" table.
- `qwen3-vl-235b-a22b-thinking` fully removed from the SDK.

## Why this is blocking
The cookbook PRs ([#63](https://github.com/perceptron-ai-inc/perceptron/pull/63), [#64](https://github.com/perceptron-ai-inc/perceptron/pull/64), [#66](https://github.com/perceptron-ai-inc/perceptron/pull/66)) all install via `%pip install --upgrade perceptron --quiet` and call `model="isaac-0.3-max"`. Until v0.3.1 is on PyPI those notebooks raise `BadRequestError` on the SDK pre-flight when run in Colab — the allowlist fix sits on `main` but isn't shipped yet.

## Test plan
- [x] `git diff` shows only the two version strings change.
- [ ] Merge → cut `v0.3.1` tag → CI publishes to PyPI.
- [ ] After PyPI publishes, run the cookbook notebooks in Colab end-to-end against `isaac-0.3-max`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)