### PR TITLE
Fix dead classes_text in PPE detection prompt

### DIFF
--- a/cookbook/recipes/capabilities/object-detection/object-detection.ipynb
+++ b/cookbook/recipes/capabilities/object-detection/object-detection.ipynb
@@ -76,20 +76,7 @@
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "TARGET_CLASSES = [\"safety helmet\", \"safety vest\"]\n",
-    "\n",
-    "\n",
-    "@perceive(expects=\"box\", allow_multiple=True)\n",
-    "def detect_ppe(frame_path):\n",
-    "    frame = image(frame_path)\n",
-    "    classes_text = \", \".join(TARGET_CLASSES)\n",
-    "    prompt = text(\n",
-    "        \"Find every worker wearing PPE. Focus on helmets and high-visibility vests. \"\n",
-    "        \"Return one bounding box per instance and include the item name in the mention attribute.\"\n",
-    "    )\n",
-    "    return frame + prompt"
-   ]
+   "source": "TARGET_CLASSES = [\"safety helmet\", \"safety vest\"]\n\n\n@perceive(expects=\"box\", allow_multiple=True)\ndef detect_ppe(frame_path):\n    frame = image(frame_path)\n    classes_text = \", \".join(TARGET_CLASSES)\n    prompt = text(\n        f\"Detect each individual instance of these items: {classes_text}. \"\n        f\"Return one bounding box per item (not per person). \"\n        f\"Set the mention attribute to the matching class name from this list.\"\n    )\n    return frame + prompt"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
The PPE detection prompt in `cookbook/recipes/capabilities/object-detection/object-detection.ipynb` computed `classes_text` from `TARGET_CLASSES` but **never inserted it** into the f-string sent to the model.

As a result:
- The structured class list (`safety helmet`, `safety vest`) never reached the model.
- The prompt asked the model to find "every worker wearing PPE" — so the model boxed *workers* (people), not the PPE items.

### Before (1 over-broad box)
```
<point_box mention="worker wearing PPE"> (325,198) (607,904) </point_box>
```

### After (2 correct per-item boxes)
```
<point_box mention="safety helmet"> (383,200) (528,286) </point_box>
<point_box mention="safety vest"> (377,319) (562,575) </point_box>
```

Verified against `isaac-0.1` (the model the legacy notebook configures).

## Why
`classes_text` was already being computed — clearly intended to be in the prompt — and its absence was a copy/paste oversight that made the demo silently degrade.

## Test plan
- [x] `tools/run_notebooks.py --root cookbook/recipes/capabilities/object-detection/` — passes
- [x] Manually inspected request body sent to isaac-0.1 — confirms class list now in the prompt
- [x] Manually inspected response — 2 correctly-labeled boxes instead of 1 generic person box

## Related
Same bug existed in the parallel `cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb`; that fix is bundled into PR #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)