### PR TITLE
Rename cookbook to Perceptron Mk1 (folders, files, model refs)

### DIFF
--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -10,7 +10,8 @@ Hands-on quickstarts, capability recipes, and end-to-end tutorials for building 
 
 | Notebook | What it covers | Colab |
 | --- | --- | --- |
-| [`quickstart_isaac`](quickstart/quickstart_isaac/quickstart_isaac.ipynb) | Run the Isaac 0.2 model to localize shipping boxes in a factory scene. | [Open in Colab](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb) |
+| [`quickstart_perceptron`](quickstart/quickstart_perceptron/quickstart_perceptron.ipynb) | Run Perceptron Mk1 on an image and ask a natural-language question about it. | [Open in Colab](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_perceptron/quickstart_perceptron.ipynb) |
+| [`quickstart_perceptron_video`](quickstart/quickstart_perceptron_video/quickstart_perceptron_video.ipynb) | Run Perceptron Mk1 on a video and ask a natural-language question about it. | [Open in Colab](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_perceptron_video/quickstart_perceptron_video.ipynb) |
 
 ---
 
@@ -28,20 +29,20 @@ Hands-on quickstarts, capability recipes, and end-to-end tutorials for building 
 
 > **When to use `detect()` vs `@perceive`?** Use `detect()` for quick, single-shot helpers. Reach for `@perceive` when you want to embed custom prompts, streaming, or multi-step logic inside your own pipeline.
 
-### Isaac 0.3 Max sibling recipes
+### Perceptron Mk1 sibling recipes
 
-The same capabilities, configured for the flagship `isaac-0.3-max` model and using the post-v0.3.0 SDK API. Image-only legacy recipes above remain valid for the 0.x family.
+The same capabilities, configured for the flagship `mk1` model and using the post-v0.3.0 SDK API. Image-only legacy recipes above remain valid for the 0.x family.
 
 | Notebook | Scenario | Colab |
 | --- | --- | --- |
-| [`isaac-0.3-max/image-qa`](recipes/capabilities/isaac-0.3-max/image-qa.ipynb) | Grounded Q&A with bounding-box citations on a studio scene. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb) |
-| [`isaac-0.3-max/image-captioning`](recipes/capabilities/isaac-0.3-max/image-captioning.ipynb) | Concise and detailed captions, optionally with grounded snippets. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb) |
-| [`isaac-0.3-max/object-detection`](recipes/capabilities/isaac-0.3-max/object-detection.ipynb) | PPE detection via the `@perceive` helper with `expects="box"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb) |
-| [`isaac-0.3-max/ocr`](recipes/capabilities/isaac-0.3-max/ocr.ipynb) | OCR with custom prompts targeting product labels. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb) |
-| [`isaac-0.3-max/in-context-learning-image`](recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb) | Single-image ICL: bootstrap an exemplar, apply to a new scene. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb) |
-| [`isaac-0.3-max/video-qa`](recipes/capabilities/isaac-0.3-max/video-qa.ipynb) | Long-form video Q&A with reasoning enabled (robot-assembly walkthrough). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-qa.ipynb) |
-| [`isaac-0.3-max/video-clipping`](recipes/capabilities/isaac-0.3-max/video-clipping.ipynb) | Temporal grounding: return start/end timestamps via `expects="clip"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-clipping.ipynb) |
-| [`isaac-0.3-max/in-context-learning-video`](recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb) | Multimodal ICL: example image + intent → query video → clip back. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb) |
+| [`mk1/image-qa`](recipes/capabilities/mk1/image-qa.ipynb) | Grounded Q&A with bounding-box citations on a studio scene. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/image-qa.ipynb) |
+| [`mk1/image-captioning`](recipes/capabilities/mk1/image-captioning.ipynb) | Concise and detailed captions, optionally with grounded snippets. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/image-captioning.ipynb) |
+| [`mk1/object-detection`](recipes/capabilities/mk1/object-detection.ipynb) | PPE detection via the `@perceive` helper with `expects="box"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/object-detection.ipynb) |
+| [`mk1/ocr`](recipes/capabilities/mk1/ocr.ipynb) | OCR with custom prompts targeting product labels. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/ocr.ipynb) |
+| [`mk1/in-context-learning-image`](recipes/capabilities/mk1/in-context-learning-image.ipynb) | Single-image ICL: bootstrap an exemplar, apply to a new scene. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-image.ipynb) |
+| [`mk1/video-qa`](recipes/capabilities/mk1/video-qa.ipynb) | Long-form video Q&A with reasoning enabled (robot-assembly walkthrough). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-qa.ipynb) |
+| [`mk1/video-clipping`](recipes/capabilities/mk1/video-clipping.ipynb) | Temporal grounding: return start/end timestamps via `expects="clip"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-clipping.ipynb) |
+| [`mk1/in-context-learning-video`](recipes/capabilities/mk1/in-context-learning-video.ipynb) | Multimodal ICL: example image + intent → query video → clip back. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-video.ipynb) |
 
 ---
 

--- a/cookbook/quickstart/quickstart_perceptron/quickstart_perceptron.ipynb
+++ b/cookbook/quickstart/quickstart_perceptron/quickstart_perceptron.ipynb
@@ -33,16 +33,16 @@
    "id": "qsisaac-title",
    "metadata": {},
    "source": [
-    "# Get started with Isaac 0.3 Max — Image\n",
+    "# Get started with Perceptron Mk1 — Image\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_perceptron/quickstart_perceptron.ipynb)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "qsisaac-intro",
    "metadata": {},
-   "source": "Ask Isaac 0.3 Max a question about an image and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample image URL — no local download needed.\n\n![Studio scene sample](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp)\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or image (URL or local file path) for your own at any time.\n\n----"
+   "source": "Ask Perceptron Mk1 a question about an image and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample image URL — no local download needed.\n\n![Studio scene sample](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp)\n\n**Note**\n\nSet the `PERCEPTRON_API_KEY` environment variable (or edit the cell below) before running the call. You can swap the prompt or image (URL or local file path) for your own at any time.\n\n----"
   },
   {
    "cell_type": "markdown",
@@ -68,7 +68,7 @@
    "metadata": {},
    "source": [
     "## Configure the Perceptron client\n",
-    "Authenticate once and point the SDK at Isaac 0.3 Max."
+    "Authenticate once and point the SDK at Perceptron Mk1."
    ]
   },
   {
@@ -77,7 +77,7 @@
    "id": "qsisaac-conf",
    "metadata": {},
    "outputs": [],
-   "source": "import os\n\nfrom perceptron import configure, image, question\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.3-max\",\n    api_key=api_key,\n)\n\nIMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp\""
+   "source": "import os\n\nfrom perceptron import configure, image, question\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"mk1\",\n    api_key=api_key,\n)\n\nIMAGE_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/qna/studio_scene.webp\""
   },
   {
    "cell_type": "markdown",
@@ -99,7 +99,7 @@
    "cell_type": "markdown",
    "id": "qsisaac-next",
    "metadata": {},
-   "source": "## Next steps\n- Swap `IMAGE_URL` for your own image (URL or local file path — `image()` accepts both).\n- Tune `QUESTION` toward inspections, retrieval, or scene description.\n- Pass `expects=\"box\"`, `\"point\"`, or `\"polygon\"` to receive grounded annotations alongside the answer.\n- See the [Image Q&A capability guide](https://docs.perceptron.inc/capabilities/visual-qa) for grounded responses with bounding-box overlays.\n- For video inputs, see the [video quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb)."
+   "source": "## Next steps\n- Swap `IMAGE_URL` for your own image (URL or local file path — `image()` accepts both).\n- Tune `QUESTION` toward inspections, retrieval, or scene description.\n- Pass `expects=\"box\"`, `\"point\"`, or `\"polygon\"` to receive grounded annotations alongside the answer.\n- See the [Image Q&A capability guide](https://docs.perceptron.inc/capabilities/visual-qa) for grounded responses with bounding-box overlays.\n- For video inputs, see the [video quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_perceptron_video/quickstart_perceptron_video.ipynb)."
   }
  ],
  "metadata": {

--- a/cookbook/quickstart/quickstart_perceptron_video/quickstart_perceptron_video.ipynb
+++ b/cookbook/quickstart/quickstart_perceptron_video/quickstart_perceptron_video.ipynb
@@ -33,9 +33,9 @@
    "id": "qsvideo-title",
    "metadata": {},
    "source": [
-    "# Get started with Isaac 0.3 Max — Video\n",
+    "# Get started with Perceptron Mk1 — Video\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac_video/quickstart_isaac_video.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_perceptron_video/quickstart_perceptron_video.ipynb)"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "id": "qsvideo-intro",
    "metadata": {},
    "source": [
-    "Ask Isaac 0.3 Max a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample video URL — no local download needed.\n",
+    "Ask Perceptron Mk1 a question about a video and get a natural-language answer back. This quickstart configures the Perceptron SDK and runs a single Q&A call against a sample video URL — no local download needed.\n",
     "\n",
     "<video src=\"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\" controls width=\"640\" muted loop>\n",
     "  Your browser doesn't support the video tag.\n",
@@ -80,7 +80,7 @@
    "metadata": {},
    "source": [
     "## Configure the Perceptron client\n",
-    "Authenticate once and point the SDK at Isaac 0.3 Max."
+    "Authenticate once and point the SDK at Perceptron Mk1."
    ]
   },
   {
@@ -89,7 +89,7 @@
    "id": "qsvideo-conf",
    "metadata": {},
    "outputs": [],
-   "source": "import os\n\nfrom perceptron import configure, question, video\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"isaac-0.3-max\",\n    api_key=api_key,\n)\n\nVIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\""
+   "source": "import os\n\nfrom perceptron import configure, question, video\n\napi_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\nif not api_key or api_key.startswith(\"<\"):\n    raise RuntimeError(\"Set PERCEPTRON_API_KEY or replace the placeholder in this cell.\")\n\nconfigure(\n    provider=\"perceptron\",\n    model=\"mk1\",\n    api_key=api_key,\n)\n\nVIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/tutorials/isaac_frame_by_frame/surf.mp4\""
   },
   {
    "cell_type": "markdown",
@@ -111,7 +111,7 @@
    "cell_type": "markdown",
    "id": "qsvideo-next",
    "metadata": {},
-   "source": "## Next steps\n- Swap `VIDEO_URL` for your own MP4 or WebM (URL or local file path — `video()` accepts both).\n- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_isaac/quickstart_isaac.ipynb)."
+   "source": "## Next steps\n- Swap `VIDEO_URL` for your own MP4 or WebM (URL or local file path — `video()` accepts both).\n- Tune `QUESTION` toward summarization, event detection, or compliance checks.\n- Pass `expects=\"clip\"` to elicit temporal segments (start/end timestamps) alongside the answer.\n- For image inputs, see the [image quickstart](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/quickstart/quickstart_perceptron/quickstart_perceptron.ipynb)."
   }
  ],
  "metadata": {

--- a/cookbook/recipes/capabilities/mk1/image-captioning.ipynb
+++ b/cookbook/recipes/capabilities/mk1/image-captioning.ipynb
@@ -20,10 +20,10 @@
   {
    "cell_type": "markdown", "id": "icap-title", "metadata": {},
    "source": [
-    "# Capability — Image Captioning (Isaac 0.3 Max)\n",
+    "# Capability — Image Captioning (Perceptron Mk1)\n",
     "Generate concise or rich descriptions for any scene, optionally returning grounded regions alongside the text.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-captioning.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/image-captioning.ipynb)"
    ]
   },
   {"cell_type": "markdown", "id": "icap-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "markdown", "id": "icap-confhdr", "metadata": {},
-   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Perceptron Mk1."]
   },
   {
    "cell_type": "code", "execution_count": null, "id": "icap-conf", "metadata": {}, "outputs": [],
@@ -58,7 +58,7 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",

--- a/cookbook/recipes/capabilities/mk1/image-qa.ipynb
+++ b/cookbook/recipes/capabilities/mk1/image-qa.ipynb
@@ -20,10 +20,10 @@
   {
    "cell_type": "markdown", "id": "iqa-title", "metadata": {},
    "source": [
-    "# Capability — Image Q&A (Isaac 0.3 Max)\n",
+    "# Capability — Image Q&A (Perceptron Mk1)\n",
     "Ask natural-language questions about a scene and receive answers plus bounding boxes for supporting evidence.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/image-qa.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/image-qa.ipynb)"
    ]
   },
   {
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "markdown", "id": "iqa-confhdr", "metadata": {},
-   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Perceptron Mk1."]
   },
   {
    "cell_type": "code", "execution_count": null, "id": "iqa-conf", "metadata": {}, "outputs": [],
@@ -61,7 +61,7 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",
@@ -120,7 +120,7 @@
     "- Tune `QUESTION` toward inspections, instructions, or policy compliance checks.\n",
     "- Swap `expects` to `\"text\"` for free-form answers or keep `\"box\"` / `\"point\"` for grounded citations.\n",
     "- Pass `reasoning=True` when the answer benefits from deeper analysis.\n",
-    "- For video Q&A, see the [Video Q&A](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-qa.ipynb) notebook."
+    "- For video Q&A, see the [Video Q&A](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-qa.ipynb) notebook."
    ]
   }
  ],

--- a/cookbook/recipes/capabilities/mk1/in-context-learning-image.ipynb
+++ b/cookbook/recipes/capabilities/mk1/in-context-learning-image.ipynb
@@ -20,10 +20,10 @@
   {
    "cell_type": "markdown", "id": "icli-title", "metadata": {},
    "source": [
-    "# Capability — Single-Image In-Context Learning (Isaac 0.3 Max)\n",
+    "# Capability — Single-Image In-Context Learning (Perceptron Mk1)\n",
     "Guide the model with one exemplar image before detecting the same object in a different scene.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-image.ipynb)"
    ]
   },
   {"cell_type": "markdown", "id": "icli-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "markdown", "id": "icli-confhdr", "metadata": {},
-   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Perceptron Mk1."]
   },
   {
    "cell_type": "code", "execution_count": null, "id": "icli-conf", "metadata": {}, "outputs": [],
@@ -59,7 +59,7 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",
@@ -170,7 +170,7 @@
     "## Conclusion & next steps\n",
     "- Swap in different exemplar / target pairs to explore other categories.\n",
     "- Add more than one exemplar by appending to the `examples` list for tougher distinctions.\n",
-    "- For an open-ended (non-detection) ICL flow on a video, see [In-context learning (Video)](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb)."
+    "- For an open-ended (non-detection) ICL flow on a video, see [In-context learning (Video)](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-video.ipynb)."
    ]
   }
  ],

--- a/cookbook/recipes/capabilities/mk1/in-context-learning-video.ipynb
+++ b/cookbook/recipes/capabilities/mk1/in-context-learning-video.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "vclip-cprt",
+   "id": "iclv-cprt",
    "metadata": {},
    "source": [
     "##### Copyright 2025 Perceptron AI."
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vclip-lic",
+   "id": "iclv-lic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,28 +30,34 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-title",
+   "id": "iclv-title",
    "metadata": {},
    "source": [
-    "# Capability — Video Clipping\n",
-    "Find the exact moment an event occurs in a video and return a temporal clip (start/end timestamps) grounding the answer.\n",
+    "# Capability — In-context learning (Video)\n",
+    "Show Isaac an example image of an item, then ask it to find that item in a fresh video and return a clip grounding the answer.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-clipping.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-video.ipynb)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-preview",
+   "id": "iclv-preview",
    "metadata": {},
    "source": [
-    "<video src=\"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/video-clipping/mj_shot_short.mp4\" controls width=\"640\" muted loop>\n",
+    "**Example image** (the in-context exemplar):\n",
+    "\n",
+    "![Example: mini wheats box](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/in-context-learning-video/mini_wheats.jpeg)\n",
+    "\n",
+    "**Query video** (search for the same item):\n",
+    "\n",
+    "<video src=\"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/in-context-learning-video/cereal_short.mp4\" controls width=\"640\" muted loop>\n",
     "  Your browser doesn't support the video tag.\n",
     "</video>"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-installhdr",
+   "id": "iclv-installhdr",
    "metadata": {},
    "source": [
     "## Install dependencies"
@@ -60,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vclip-install",
+   "id": "iclv-install",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,27 +75,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-dlhdr",
+   "id": "iclv-dlhdr",
    "metadata": {},
    "source": [
-    "## Download the sample video"
+    "## Download the example image and query video"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vclip-dl",
+   "id": "iclv-dl",
    "metadata": {},
    "outputs": [],
    "source": [
-    "VIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/video-clipping/mj_shot_short.mp4\"\n",
+    "ASSET_BASE = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/in-context-learning-video\"\n",
     "\n",
-    "!curl -L -so mj_shot_short.mp4 {VIDEO_URL}"
+    "!curl -L -so mini_wheats.jpeg {ASSET_BASE}/mini_wheats.jpeg\n",
+    "!curl -L -so cereal_short.mp4 {ASSET_BASE}/cereal_short.mp4"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-confhdr",
+   "id": "iclv-confhdr",
    "metadata": {},
    "source": [
     "## Configure the Perceptron client"
@@ -98,13 +105,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vclip-conf",
+   "id": "iclv-conf",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
-    "from perceptron import configure, question, video\n",
+    "from perceptron import configure, image, perceive, text, video\n",
     "\n",
     "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
     "if not api_key or api_key.startswith(\"<\"):\n",
@@ -112,32 +119,40 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",
-    "VIDEO_PATH = \"mj_shot_short.mp4\""
+    "EXAMPLE_IMAGE = \"mini_wheats.jpeg\"\n",
+    "QUERY_VIDEO = \"cereal_short.mp4\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-askhdr",
+   "id": "iclv-askhdr",
    "metadata": {},
    "source": [
-    "## Ask the model to clip the moment\n",
-    "Reasoning is on so the model can search through frames before localizing. `expects=\"clip\"` parses any `<clip>` tags the model emits into structured `Clip` objects with start/end timestamps."
+    "## Build the in-context sequence and ask\n",
+    "The sequence threads a single example image with a brief intent statement before the query video. Reasoning is on; `expects=\"clip\"` parses the model's `<clip>` tags into structured timestamps."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vclip-ask",
+   "id": "iclv-ask",
    "metadata": {},
    "outputs": [],
    "source": [
-    "QUESTION = \"Clip the exact moment the ball passes through the hoop.\"\n",
+    "@perceive(reasoning=True, expects=\"clip\")\n",
+    "def check_inventory(example_image_path: str, query_video_path: str):\n",
+    "    return (\n",
+    "        image(example_image_path)\n",
+    "        + text(\"I need to check inventory on this item.\")\n",
+    "        + video(query_video_path)\n",
+    "        + text(\"Is it in stock? Return a clip to justify your answer. Use the <clip> tag to specify clips.\")\n",
+    "    )\n",
     "\n",
-    "result = question(video(VIDEO_PATH), QUESTION, reasoning=True, expects=\"clip\")\n",
+    "result = check_inventory(EXAMPLE_IMAGE, QUERY_VIDEO)\n",
     "\n",
     "print(\"--- Reasoning ---\")\n",
     "print(result.reasoning or \"(none)\")\n",
@@ -147,23 +162,22 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-rendhdr",
+   "id": "iclv-rendhdr",
    "metadata": {},
    "source": [
-    "## Inspect the returned clips\n",
-    "Each `Clip` carries a `timestamp.at` (start, in seconds) and an optional `timestamp.until` (end). When `until` is `None`, the clip refers to a single moment rather than a range."
+    "## Inspect the returned clips"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vclip-render",
+   "id": "iclv-render",
    "metadata": {},
    "outputs": [],
    "source": [
     "clips = result.clips or []\n",
     "if not clips:\n",
-    "    print(\"No clips returned. Try rephrasing the question or pointing at a different moment.\")\n",
+    "    print(\"No clips returned - the model may have answered without grounding to a moment.\")\n",
     "else:\n",
     "    print(f\"Returned {len(clips)} clip(s):\")\n",
     "    for idx, clip in enumerate(clips, start=1):\n",
@@ -178,13 +192,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "vclip-next",
+   "id": "iclv-next",
    "metadata": {},
    "source": [
     "## Conclusion & next steps\n",
-    "- Try other event-localization prompts (\"clip every save attempt,\" \"clip when the package is dropped,\" \"clip every shot on goal\").\n",
-    "- Use `result.clips[i].timestamp.at` / `.until` to drive a video editor cut, generate a highlight reel, or label training data automatically.\n",
-    "- Pair with the [Video Q&A](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-qa.ipynb) notebook for an unstructured-text alternative when you don't need timestamps."
+    "- Add additional example shots (more images, or even short reference clips) to specify a richer concept.\n",
+    "- Adjust the intent text to express what kind of grounding you want back (\"return a clip when the violation occurs,\" \"return a clip showing the assembly step\").\n",
+    "- Pair with [Video Clipping](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-clipping.ipynb) for non-ICL temporal grounding, or with [In-context learning (Image)](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb) when the query is also an image."
    ]
   }
  ],

--- a/cookbook/recipes/capabilities/mk1/object-detection.ipynb
+++ b/cookbook/recipes/capabilities/mk1/object-detection.ipynb
@@ -20,10 +20,10 @@
   {
    "cell_type": "markdown", "id": "od-title", "metadata": {},
    "source": [
-    "# Capability — PPE Detection (Isaac 0.3 Max)\n",
+    "# Capability — PPE Detection (Perceptron Mk1)\n",
     "Locate protective equipment on an assembly line and highlight every instance with normalized Perceptron geometry.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/object-detection.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/object-detection.ipynb)"
    ]
   },
   {"cell_type": "markdown", "id": "od-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown", "id": "od-confhdr", "metadata": {},
-   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Perceptron Mk1."]
   },
   {
    "cell_type": "code", "execution_count": null, "id": "od-conf", "metadata": {}, "outputs": [],
@@ -58,7 +58,7 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",
@@ -134,7 +134,7 @@
     "## Conclusion & next steps\n",
     "- Adjust `TARGET_CLASSES` and the prompt to fit your environment.\n",
     "- Enable `stream=True` inside `@perceive` for incremental detections.\n",
-    "- Add exemplar shots (see the [in-context learning recipe](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-image.ipynb)) when classes are ambiguous.\n",
+    "- Add exemplar shots (see the [in-context learning recipe](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-image.ipynb)) when classes are ambiguous.\n",
     "- Pass `reasoning=True` for harder detection tasks."
    ]
   }

--- a/cookbook/recipes/capabilities/mk1/ocr.ipynb
+++ b/cookbook/recipes/capabilities/mk1/ocr.ipynb
@@ -20,10 +20,10 @@
   {
    "cell_type": "markdown", "id": "ocr-title", "metadata": {},
    "source": [
-    "# Capability — OCR with Custom Prompts (Isaac 0.3 Max)\n",
+    "# Capability — OCR with Custom Prompts (Perceptron Mk1)\n",
     "Extract structured text from product imagery while tailoring the prompt to your downstream format.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/ocr.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/ocr.ipynb)"
    ]
   },
   {"cell_type": "markdown", "id": "ocr-installhdr", "metadata": {}, "source": ["## Install dependencies"]},
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "markdown", "id": "ocr-confhdr", "metadata": {},
-   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Isaac 0.3 Max."]
+   "source": ["## Configure the Perceptron client\nAuthenticate once and point the SDK at Perceptron Mk1."]
   },
   {
    "cell_type": "code", "execution_count": null, "id": "ocr-conf", "metadata": {}, "outputs": [],
@@ -57,7 +57,7 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",

--- a/cookbook/recipes/capabilities/mk1/video-clipping.ipynb
+++ b/cookbook/recipes/capabilities/mk1/video-clipping.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "iclv-cprt",
+   "id": "vclip-cprt",
    "metadata": {},
    "source": [
     "##### Copyright 2025 Perceptron AI."
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iclv-lic",
+   "id": "vclip-lic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,34 +30,28 @@
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-title",
+   "id": "vclip-title",
    "metadata": {},
    "source": [
-    "# Capability — In-context learning (Video)\n",
-    "Show Isaac an example image of an item, then ask it to find that item in a fresh video and return a clip grounding the answer.\n",
+    "# Capability — Video Clipping\n",
+    "Find the exact moment an event occurs in a video and return a temporal clip (start/end timestamps) grounding the answer.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/in-context-learning-video.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-clipping.ipynb)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-preview",
+   "id": "vclip-preview",
    "metadata": {},
    "source": [
-    "**Example image** (the in-context exemplar):\n",
-    "\n",
-    "![Example: mini wheats box](https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/in-context-learning-video/mini_wheats.jpeg)\n",
-    "\n",
-    "**Query video** (search for the same item):\n",
-    "\n",
-    "<video src=\"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/in-context-learning-video/cereal_short.mp4\" controls width=\"640\" muted loop>\n",
+    "<video src=\"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/video-clipping/mj_shot_short.mp4\" controls width=\"640\" muted loop>\n",
     "  Your browser doesn't support the video tag.\n",
     "</video>"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-installhdr",
+   "id": "vclip-installhdr",
    "metadata": {},
    "source": [
     "## Install dependencies"
@@ -66,7 +60,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iclv-install",
+   "id": "vclip-install",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,28 +69,27 @@
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-dlhdr",
+   "id": "vclip-dlhdr",
    "metadata": {},
    "source": [
-    "## Download the example image and query video"
+    "## Download the sample video"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iclv-dl",
+   "id": "vclip-dl",
    "metadata": {},
    "outputs": [],
    "source": [
-    "ASSET_BASE = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/in-context-learning-video\"\n",
+    "VIDEO_URL = \"https://raw.githubusercontent.com/perceptron-ai-inc/perceptron/main/cookbook/_shared/assets/capabilities/video-clipping/mj_shot_short.mp4\"\n",
     "\n",
-    "!curl -L -so mini_wheats.jpeg {ASSET_BASE}/mini_wheats.jpeg\n",
-    "!curl -L -so cereal_short.mp4 {ASSET_BASE}/cereal_short.mp4"
+    "!curl -L -so mj_shot_short.mp4 {VIDEO_URL}"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-confhdr",
+   "id": "vclip-confhdr",
    "metadata": {},
    "source": [
     "## Configure the Perceptron client"
@@ -105,13 +98,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iclv-conf",
+   "id": "vclip-conf",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "\n",
-    "from perceptron import configure, image, perceive, text, video\n",
+    "from perceptron import configure, question, video\n",
     "\n",
     "api_key = os.getenv(\"PERCEPTRON_API_KEY\", \"<your Perceptron API key>\")\n",
     "if not api_key or api_key.startswith(\"<\"):\n",
@@ -119,40 +112,32 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",
-    "EXAMPLE_IMAGE = \"mini_wheats.jpeg\"\n",
-    "QUERY_VIDEO = \"cereal_short.mp4\""
+    "VIDEO_PATH = \"mj_shot_short.mp4\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-askhdr",
+   "id": "vclip-askhdr",
    "metadata": {},
    "source": [
-    "## Build the in-context sequence and ask\n",
-    "The sequence threads a single example image with a brief intent statement before the query video. Reasoning is on; `expects=\"clip\"` parses the model's `<clip>` tags into structured timestamps."
+    "## Ask the model to clip the moment\n",
+    "Reasoning is on so the model can search through frames before localizing. `expects=\"clip\"` parses any `<clip>` tags the model emits into structured `Clip` objects with start/end timestamps."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iclv-ask",
+   "id": "vclip-ask",
    "metadata": {},
    "outputs": [],
    "source": [
-    "@perceive(reasoning=True, expects=\"clip\")\n",
-    "def check_inventory(example_image_path: str, query_video_path: str):\n",
-    "    return (\n",
-    "        image(example_image_path)\n",
-    "        + text(\"I need to check inventory on this item.\")\n",
-    "        + video(query_video_path)\n",
-    "        + text(\"Is it in stock? Return a clip to justify your answer. Use the <clip> tag to specify clips.\")\n",
-    "    )\n",
+    "QUESTION = \"Clip the exact moment the ball passes through the hoop.\"\n",
     "\n",
-    "result = check_inventory(EXAMPLE_IMAGE, QUERY_VIDEO)\n",
+    "result = question(video(VIDEO_PATH), QUESTION, reasoning=True, expects=\"clip\")\n",
     "\n",
     "print(\"--- Reasoning ---\")\n",
     "print(result.reasoning or \"(none)\")\n",
@@ -162,22 +147,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-rendhdr",
+   "id": "vclip-rendhdr",
    "metadata": {},
    "source": [
-    "## Inspect the returned clips"
+    "## Inspect the returned clips\n",
+    "Each `Clip` carries a `timestamp.at` (start, in seconds) and an optional `timestamp.until` (end). When `until` is `None`, the clip refers to a single moment rather than a range."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iclv-render",
+   "id": "vclip-render",
    "metadata": {},
    "outputs": [],
    "source": [
     "clips = result.clips or []\n",
     "if not clips:\n",
-    "    print(\"No clips returned - the model may have answered without grounding to a moment.\")\n",
+    "    print(\"No clips returned. Try rephrasing the question or pointing at a different moment.\")\n",
     "else:\n",
     "    print(f\"Returned {len(clips)} clip(s):\")\n",
     "    for idx, clip in enumerate(clips, start=1):\n",
@@ -192,13 +178,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "iclv-next",
+   "id": "vclip-next",
    "metadata": {},
    "source": [
     "## Conclusion & next steps\n",
-    "- Add additional example shots (more images, or even short reference clips) to specify a richer concept.\n",
-    "- Adjust the intent text to express what kind of grounding you want back (\"return a clip when the violation occurs,\" \"return a clip showing the assembly step\").\n",
-    "- Pair with [Video Clipping](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-clipping.ipynb) for non-ICL temporal grounding, or with [In-context learning (Image)](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb) when the query is also an image."
+    "- Try other event-localization prompts (\"clip every save attempt,\" \"clip when the package is dropped,\" \"clip every shot on goal\").\n",
+    "- Use `result.clips[i].timestamp.at` / `.until` to drive a video editor cut, generate a highlight reel, or label training data automatically.\n",
+    "- Pair with the [Video Q&A](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-qa.ipynb) notebook for an unstructured-text alternative when you don't need timestamps."
    ]
   }
  ],

--- a/cookbook/recipes/capabilities/mk1/video-qa.ipynb
+++ b/cookbook/recipes/capabilities/mk1/video-qa.ipynb
@@ -36,7 +36,7 @@
     "# Capability — Video Q&A\n",
     "Ask a question about a short video and get a structured natural-language answer back, with reasoning enabled.\n",
     "\n",
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-qa.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-qa.ipynb)"
    ]
   },
   {
@@ -93,7 +93,7 @@
    "metadata": {},
    "source": [
     "## Configure the Perceptron client\n",
-    "Authenticate once and point the SDK at Isaac 0.3 Max."
+    "Authenticate once and point the SDK at Perceptron Mk1."
    ]
   },
   {
@@ -113,7 +113,7 @@
     "\n",
     "configure(\n",
     "    provider=\"perceptron\",\n",
-    "    model=\"isaac-0.3-max\",\n",
+    "    model=\"mk1\",\n",
     "    api_key=api_key,\n",
     ")\n",
     "\n",
@@ -150,7 +150,7 @@
    "cell_type": "markdown",
    "id": "vqa-next",
    "metadata": {},
-   "source": "## Next steps\n- Swap `VIDEO_PATH` for your own MP4 or WebM (URL or local file path; max ~60 seconds at 1 fps sampling).\n- Tune `QUESTION` toward summarization, compliance checks, or step decomposition.\n- Set `reasoning=False` for faster, lighter responses on simpler queries.\n- For temporal segments (start/end timestamps), see the [Video Clipping](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/isaac-0.3-max/video-clipping.ipynb) notebook."
+   "source": "## Next steps\n- Swap `VIDEO_PATH` for your own MP4 or WebM (URL or local file path; max ~60 seconds at 1 fps sampling).\n- Tune `QUESTION` toward summarization, compliance checks, or step decomposition.\n- Set `reasoning=False` for faster, lighter responses on simpler queries.\n- For temporal segments (start/end timestamps), see the [Video Clipping](https://github.com/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-clipping.ipynb) notebook."
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
Renames the cookbook's \`isaac-0.3-max\` folder + \`quickstart_isaac*\` folders to the new public names, and updates every notebook to use \`model="mk1"\` and the Mk1 display name.

## Folder renames (git mv preserves history)
- \`cookbook/recipes/capabilities/isaac-0.3-max/\`  → \`mk1/\`
- \`cookbook/quickstart/quickstart_isaac/\`         → \`quickstart_perceptron/\`
- \`cookbook/quickstart/quickstart_isaac_video/\`   → \`quickstart_perceptron_video/\`

Notebook files within each folder were renamed accordingly (\`quickstart_isaac.ipynb\` → \`quickstart_perceptron.ipynb\`, etc.).

## Notebook content updates
sed across all 10 \`.ipynb\` files + \`cookbook/README.md\`:

| Replacement | Where |
|---|---|
| \`isaac-0.3-max\` → \`mk1\` | Model strings (\`model="mk1"\`), internal cookbook URLs in markdown cells |
| \`Isaac 0.3 Max\` → \`Perceptron Mk1\` | Display references in titles and prose |
| \`quickstart_isaac*\` → \`quickstart_perceptron*\` | Cross-link URLs in markdown cells |

## README cleanup
- Fixed stale quickstart description ("Run the Isaac 0.2 model …" → "Run Perceptron Mk1 …").
- Added a row for the video quickstart that was missing from the table.

## ⚠️ Heads-up — depends on SDK update

The SDK on PyPI (v0.3.2) hard-codes \`isaac-0.3-max\` in its \`supported_models\` allowlist (\`src/perceptron/client.py:526\`). Running the renamed notebooks against \`pip install perceptron\` will currently raise:

\`\`\`
BadRequestError: Model 'mk1' is not supported
\`\`\`

A companion SDK PR adding \`mk1\` to the allowlist is required before this PR's CI passes and before notebooks should ship for external users. I'll open that PR next.

## Test plan
- [ ] Land the companion SDK PR adding \`mk1\` to \`supported_models\` (+ publish to PyPI as v0.3.3)
- [ ] Re-run notebooks CI — expect green
- [ ] Land this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)