### PR TITLE
Lead READMEs, cookbook, and SDK default with Perceptron Mk1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://codecov.io/github/perceptron-ai-inc/perceptron"><img src="https://codecov.io/github/perceptron-ai-inc/perceptron/graph/badge.svg?token=HW6JASKQJR" alt="codecov"></a>
 </p>
 
-**Perceptron is the Python SDK for building with perceptive-language models like Isaac 0.1.** Designed for physical AI applications—robotics, manufacturing, logistics, and security—it provides a unified interface for grounded perception: detection, localization, OCR, and visual Q&A with structured outputs ready for robotics, analytics, and edge deployment. Route tasks to specialized models, swap providers per call, and compose complex multimodal flows with a typed DSL. Efficient enough for edge deployment, flexible enough for any real-world task.
+**Perceptron is the Python SDK for building with perceptive-language models, from our flagship Perceptron Mk1 to edge-ready models like Isaac 0.2 2B (Preview).** Designed for physical AI applications—robotics, manufacturing, logistics, and security—it provides a unified interface for grounded perception: detection, localization, OCR, and visual Q&A with structured outputs ready for robotics, analytics, and edge deployment. Route tasks to specialized models, swap providers per call, and compose complex multimodal flows with a typed DSL. Efficient enough for edge deployment, flexible enough for any real-world task.
 
 <p align="center">
   <a href="https://www.perceptron.inc/" target="_blank"><strong>Website</strong></a> ·
@@ -31,8 +31,11 @@ Get precise localization and grounded answers with conversational pointing—eve
 **In-context learning for perception**
 Show a few annotated examples (defects, safety conditions, custom categories) in your prompt and the model adapts—no YOLO-style fine-tuning or custom detector stacks required. Learn novel tasks from a handful of examples.
 
-**Efficient frontier for real-world deployment**
-Isaac 0.1 matches models 50x its size while delivering edge-ready latencies and drastically lower serving costs. Perception workloads are continuous and latency-sensitive—Perceptron is built for the efficient frontier where capability meets real-world constraints.
+**Flagship reasoning across image and video**
+Perceptron Mk1, our flagship, brings grounded perception to long-form video—Q&A, temporal clipping, and multimodal in-context learning—on top of the image capabilities shared with the Isaac family. Built for cloud workloads where capability outweighs footprint.
+
+**Efficient frontier for edge deployment**
+The Isaac family is built for the edge—Isaac 0.1 matches models 50x its size, with Isaac 0.2 2B (Preview) extending the lineup. Both deliver edge-ready latencies and drastically lower serving costs. Perception workloads are continuous and latency-sensitive—Perceptron is built for the efficient frontier where capability meets real-world constraints.
 
 **Prompt for anything, control the output type**
 Ask for whatever you need in natural language—"find safety violations", "locate damaged components", "identify obstacles"—and specify the output format: bounding boxes, points, polygons, or text. The flexibility of language models with the structure your application needs.
@@ -70,7 +73,7 @@ The CLI entry point `perceptron` is available after install.
 ```python
 from perceptron import detect, caption
 
-# Detect objects with structured bounding boxes
+# Detect objects with structured bounding boxes (uses Perceptron Mk1 by default)
 result = detect(
     "warehouse.jpg",
     classes=["forklift", "person", "pallet"]
@@ -88,11 +91,12 @@ No credentials? The SDK returns compile-only payloads when API keys are missing,
 
 ## Configuration
 
-Set credentials once via environment, code, or the CLI. The SDK ships with the Perceptron backend enabled by default, and you can add or swap providers (e.g., `fal`) by extending `perceptron.client._PROVIDER_CONFIG`.
+Set credentials once via environment, code, or the CLI. The SDK ships with the Perceptron backend enabled by default and `mk1` selected as the default model — override per call with `model=...`. You can add or swap providers (e.g., `fal`) by extending `perceptron.client._PROVIDER_CONFIG`.
 
 **Environment variables (pick what you need):**
 - `PERCEPTRON_PROVIDER` – provider identifier (`perceptron` by default)
 - `PERCEPTRON_API_KEY` – API key for the selected provider
+- `PERCEPTRON_MODEL` – override the default model (e.g., `mk1`, `isaac-0.1`)
 - Provider-specific keys (e.g., `FAL_KEY`) when targeting alternates
 
 ```bash

--- a/cookbook/README.md
+++ b/cookbook/README.md
@@ -17,21 +17,9 @@ Hands-on quickstarts, capability recipes, and end-to-end tutorials for building 
 
 ## Capability Recipes
 
-| Notebook | Scenario | Colab |
-| --- | --- | --- |
-| [`captioning`](recipes/capabilities/captioning/captioning.ipynb) | Generate concise or grounded captions (with bounding boxes). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/captioning/captioning.ipynb) |
-| [`ocr`](recipes/capabilities/ocr/ocr.ipynb) | Run OCR with custom prompts and parse the output. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/ocr/ocr.ipynb) |
-| [`object-detection`](recipes/capabilities/object-detection/object-detection.ipynb) | Detect PPE with a `@perceive` helper or the high-level `detect()` API. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/object-detection/object-detection.ipynb) |
-| [`visual-qa`](recipes/capabilities/visual-qa/visual-qa.ipynb) | Ask grounded questions and cite regions with bounding boxes. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/visual-qa/visual-qa.ipynb) |
-| [`in-context-learning`](recipes/capabilities/in-context-learning/in-context-learning.ipynb) | Single-image in-context detection (bootstrap exemplar → apply to target). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb) |
-| [`multi-image-in-context-learning`](recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb) | Multi-shot guidance to classify/ground multiple categories at once. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb) |
-| [`constrained-decoding`](recipes/capabilities/constrained-decoding/constrained-decoding.ipynb) | Force structured output with Pydantic schemas or regex patterns. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb) |
+### Perceptron Mk1
 
-> **When to use `detect()` vs `@perceive`?** Use `detect()` for quick, single-shot helpers. Reach for `@perceive` when you want to embed custom prompts, streaming, or multi-step logic inside your own pipeline.
-
-### Perceptron Mk1 sibling recipes
-
-The same capabilities, configured for the flagship `mk1` model and using the post-v0.3.0 SDK API. Image-only legacy recipes above remain valid for the 0.x family.
+Image and video recipes for the flagship `mk1` model, using the v0.3.4+ SDK API. Mk1 adds long-form video Q&A, temporal clipping, and multimodal in-context learning on top of the image capabilities.
 
 | Notebook | Scenario | Colab |
 | --- | --- | --- |
@@ -44,9 +32,27 @@ The same capabilities, configured for the flagship `mk1` model and using the pos
 | [`mk1/video-clipping`](recipes/capabilities/mk1/video-clipping.ipynb) | Temporal grounding: return start/end timestamps via `expects="clip"`. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/video-clipping.ipynb) |
 | [`mk1/in-context-learning-video`](recipes/capabilities/mk1/in-context-learning-video.ipynb) | Multimodal ICL: example image + intent → query video → clip back. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/mk1/in-context-learning-video.ipynb) |
 
+> **When to use `detect()` vs `@perceive`?** Use `detect()` for quick, single-shot helpers. Reach for `@perceive` when you want to embed custom prompts, streaming, or multi-step logic inside your own pipeline.
+
+### Isaac family
+
+Image-only recipes pinned to the Isaac 0.1 / 0.2 family — useful as a reference when targeting the edge-tier models.
+
+| Notebook | Scenario | Colab |
+| --- | --- | --- |
+| [`captioning`](recipes/capabilities/captioning/captioning.ipynb) | Generate concise or grounded captions (with bounding boxes). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/captioning/captioning.ipynb) |
+| [`ocr`](recipes/capabilities/ocr/ocr.ipynb) | Run OCR with custom prompts and parse the output. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/ocr/ocr.ipynb) |
+| [`object-detection`](recipes/capabilities/object-detection/object-detection.ipynb) | Detect PPE with a `@perceive` helper or the high-level `detect()` API. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/object-detection/object-detection.ipynb) |
+| [`visual-qa`](recipes/capabilities/visual-qa/visual-qa.ipynb) | Ask grounded questions and cite regions with bounding boxes. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/visual-qa/visual-qa.ipynb) |
+| [`in-context-learning`](recipes/capabilities/in-context-learning/in-context-learning.ipynb) | Single-image in-context detection (bootstrap exemplar → apply to target). | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/in-context-learning/in-context-learning.ipynb) |
+| [`multi-image-in-context-learning`](recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb) | Multi-shot guidance to classify/ground multiple categories at once. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/multi-image-in-context-learning/multi-image-in-context-learning.ipynb) |
+| [`constrained-decoding`](recipes/capabilities/constrained-decoding/constrained-decoding.ipynb) | Force structured output with Pydantic schemas or regex patterns. | [Launch](https://colab.research.google.com/github/perceptron-ai-inc/perceptron/blob/main/cookbook/recipes/capabilities/constrained-decoding/constrained-decoding.ipynb) |
+
 ---
 
 ## Tutorials
+
+> For native video Q&A with Mk1, see the [`mk1/video-qa`](recipes/capabilities/mk1/video-qa.ipynb) recipe above.
 
 | Notebook | Description | Colab |
 | --- | --- | --- |

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -1,5 +1,7 @@
 # Isaac on HuggingFace 
 
+This page covers loading the Isaac 0.1 weights from HuggingFace. For our flagship Perceptron Mk1, see the [Perceptron SDK](https://github.com/perceptron-ai-inc/perceptron) and [docs](https://docs.perceptron.inc).
+
 ## Loading Isaac v0.1
 ```python
 from transformers import AutoTokenizer, AutoConfig, AutoModelForCausalLM

--- a/src/perceptron/client.py
+++ b/src/perceptron/client.py
@@ -518,7 +518,7 @@ _PROVIDER_CONFIG = {
         "auth_header": "Authorization",
         "auth_prefix": "Bearer ",
         "env_keys": ["PERCEPTRON_API_KEY"],
-        "default_model": "isaac-0.1",
+        "default_model": "mk1",
         "supported_models": [
             "isaac-0.1",
             "isaac-0.2-1b",


### PR DESCRIPTION
## Summary
- **Root README**: span the model lineup in the opening paragraph (flagship Mk1 to edge-ready Isaac 0.2 2B (Preview)), split the Why-Perceptron model bullet into a Mk1 flagship story and an edge bullet for the Isaac family, note the new default model in the Configuration section and Quick Start example, and document `PERCEPTRON_MODEL`.
- **Cookbook README**: reorder Capability Recipes so the Mk1 table is primary and the Isaac family sits below as an edge-tier reference; bump SDK API version string to v0.3.4+; cross-link the Isaac frame-by-frame tutorial to the native Mk1 `video-qa` recipe.
- **HuggingFace README**: point readers to the Perceptron SDK and docs for the flagship Mk1.
- **SDK**: flip the `perceptron` provider's `default_model` from `isaac-0.1` to `mk1`.

Follow-up to #75 (model rename).

## Test plan
- [ ] `pytest tests/test_prompt_profiles.py tests/test_transport_payloads.py tests/test_expectations_reasoning.py` (passes locally).
- [ ] Render `README.md`, `cookbook/README.md`, and `huggingface/README.md` on GitHub and confirm the updated sections read naturally.