### PR TITLE
Clip should be included in parsed

### DIFF
--- a/src/perceptron/client.py
+++ b/src/perceptron/client.py
@@ -184,7 +184,7 @@ class _StreamProcessor:
         if expects in _BUCKET_BY_EXPECTS and self._parsing_enabled and isinstance(content, str):
             bucket_name, extract = _BUCKET_BY_EXPECTS[expects]
             result[bucket_name] = extract(content)
-            result["parsed"] = parse_text(content)
+            result["parsed"] = parse_text(content, expects=expects)
         issues: list[dict[str, Any]] = []
         if not self._parsing_enabled:
             issues.append(
@@ -208,7 +208,7 @@ class _StreamProcessor:
         if expects not in _BUCKET_BY_EXPECTS:
             return events
         try:
-            segments = parse_text(self._cumulative)
+            segments = parse_text(self._cumulative, expects=expects)
         except Exception:
             return events
         for seg in segments:
@@ -783,7 +783,7 @@ class _ClientCore:
         if expects in _BUCKET_BY_EXPECTS and isinstance(content, str):
             bucket_name, extract = _BUCKET_BY_EXPECTS[expects]
             result[bucket_name] = extract(content)
-            result["parsed"] = parse_text(content)
+            result["parsed"] = parse_text(content, expects=expects)
         return result
 
 

--- a/src/perceptron/pointing/parser.py
+++ b/src/perceptron/pointing/parser.py
@@ -5,16 +5,19 @@ Supported tags
 - <point_box [mention=...][t=FLOAT]> (x1,y1) (x2,y2) </point_box>
 - <polygon [mention=...][t=FLOAT]> (x1,y1) (x2,y2) (x3,y3) ... </polygon>
 - <collection> ...child point/box/polygon tags... </collection>
+- <clip [mention=...] t=FLOAT[ FLOAT] />  (self-closing; moment or [at, until] range)
 
 Helpers
 - parse_text(text) → ordered segments: text and structured tags with spans
 - extract_points(text, expected) → filtered list of point/box/polygon
+- extract_clips(text) → list of clip annotations (with mention inheritance inside collections)
 - strip_tags(text) → remove all canonical tags
 """
 
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from contextlib import suppress
 from dataclasses import dataclass, replace
 from html import escape, unescape
@@ -174,16 +177,40 @@ class PointParser:
         return [seg for seg in parse_text(text) if seg.get("kind") != "text"]
 
 
-def parse_text(text: str) -> list[dict[str, Any]]:
+def parse_text(text: str, *, expects: str | None = None) -> list[dict[str, Any]]:
     """Return ordered segments: text and tag segments with spans.
+
+    The `expects` parameter selects which tag family to scan for, so callers
+    don't pay for parsing tags they don't care about:
+      - ``"clip"``: scan self-closing ``<clip />`` tags only
+      - ``"point"`` | ``"box"`` | ``"polygon"`` | ``None``: scan
+        point/point_box/polygon/collection tags (default — preserves the
+        original geometry-only contract)
+      - anything else: no tag parsing; the input is returned as a single
+        text segment
 
     Segment shapes:
       - {"kind": "text", "text": str, "span": {"start": int, "end": int}}
       - {"kind": "point"|"box"|"polygon"|"collection", "value": obj, "span": {...}}
+      - {"kind": "clip", "value": Clip, "span": {...}}
     """
+    if expects == "clip":
+        pattern, handler = _CLIP_TAG, _clip_match_to_segment
+    elif expects is None or expects in {"point", "box", "polygon"}:
+        pattern, handler = _FULL_TAG, _shape_match_to_segment
+    else:
+        return [{"kind": "text", "text": text, "span": {"start": 0, "end": len(text)}}] if text else []
+    return _scan_segments(text, pattern, handler)
+
+
+def _scan_segments(
+    text: str,
+    pattern: re.Pattern[str],
+    handler: Callable[[re.Match[str]], tuple[str, Any]],
+) -> list[dict[str, Any]]:
     segments: list[dict[str, Any]] = []
     idx = 0
-    for m in _FULL_TAG.finditer(text):
+    for m in pattern.finditer(text):
         if m.start() > idx:
             segments.append(
                 {
@@ -192,27 +219,8 @@ def parse_text(text: str) -> list[dict[str, Any]]:
                     "span": {"start": idx, "end": m.start()},
                 }
             )
-        tag = m.group("tag").lower()
-        inner_body = m.group("body") or ""
-        attrs = _parse_attrs(m.group("attrs") or "")
-        if tag == "point":
-            obj = _parse_point_body(inner_body)
-            kind = "point"
-        elif tag == "point_box":
-            obj = _parse_box_body(inner_body)
-            kind = "box"
-        elif tag == "polygon":
-            obj = _parse_polygon_body(inner_body)
-            kind = "polygon"
-        else:  # collection
-            obj = _parse_collection_body(inner_body)
-            kind = "collection"
-        if "mention" in attrs:
-            obj.mention = attrs["mention"]
-            if "t" in attrs:
-                with suppress(ValueError):
-                    obj.t = float(attrs["t"])
-        segments.append({"kind": kind, "value": obj, "span": {"start": m.start(), "end": m.end()}})
+        kind, value = handler(m)
+        segments.append({"kind": kind, "value": value, "span": {"start": m.start(), "end": m.end()}})
         idx = m.end()
     if idx < len(text):
         segments.append(
@@ -223,6 +231,48 @@ def parse_text(text: str) -> list[dict[str, Any]]:
             }
         )
     return segments
+
+
+def _shape_match_to_segment(m: re.Match[str]) -> tuple[str, Any]:
+    tag = m.group("tag").lower()
+    inner_body = m.group("body") or ""
+    attrs = _parse_attrs(m.group("attrs") or "")
+    obj: SinglePoint | BoundingBox | Polygon | Collection
+    if tag == "point":
+        obj = _parse_point_body(inner_body)
+        kind = "point"
+    elif tag == "point_box":
+        obj = _parse_box_body(inner_body)
+        kind = "box"
+    elif tag == "polygon":
+        obj = _parse_polygon_body(inner_body)
+        kind = "polygon"
+    else:  # collection
+        obj = _parse_collection_body(inner_body)
+        kind = "collection"
+    if "mention" in attrs:
+        obj.mention = attrs["mention"]
+        if "t" in attrs:
+            with suppress(ValueError):
+                obj.t = float(attrs["t"])
+    return kind, obj
+
+
+def _clip_match_to_segment(m: re.Match[str]) -> tuple[str, Any]:
+    return "clip", _parse_clip_body(m.group("attrs") or "")
+
+
+def _parse_clip_body(attrs: str) -> Clip:
+    """Parse a self-closing `<clip />` tag's attributes into a Clip. Raises ParseError if t is missing or unparseable."""
+    ts = _parse_clip_t(attrs)
+    if ts is None:
+        raise ParseError(
+            f"Malformed <clip /> tag: expected a numeric t= attribute (e.g., t=1.5 or t=\"1.5 2.0\") but got attrs: {attrs!r}",
+            code="invalid_clip_timestamp",
+            details={"attrs": attrs},
+        )
+    mention = _parse_attrs(attrs).get("mention")
+    return Clip(timestamp=ts, mention=mention)
 
 
 def _kind_of(obj: Any) -> str | None:

--- a/tests/test_pointing_parser.py
+++ b/tests/test_pointing_parser.py
@@ -9,6 +9,8 @@ from perceptron.pointing.parser import (
 )
 from perceptron.pointing.types import (
     BoundingBox,
+    Clip,
+    ClipTimestamp,
     Collection,
     Polygon,
     SinglePoint,
@@ -197,3 +199,61 @@ class TestParseErrorOnMalformedTags:
         segs = parse_text(text)
         assert len(segs) == 1
         assert segs[0]["kind"] == "polygon"
+
+
+class TestParseTextClipSegments:
+    """With expects='clip', parse_text scans only <clip /> tags."""
+
+    def test_top_level_clip_emits_clip_segment(self):
+        text = 'before <clip mention="intro" t=1.5/> after'
+        segs = parse_text(text, expects="clip")
+        kinds = [s["kind"] for s in segs]
+        assert kinds == ["text", "clip", "text"]
+        clip_seg = segs[1]
+        assert clip_seg["value"] == Clip(timestamp=ClipTimestamp(at=1.5), mention="intro")
+        assert clip_seg["span"]["start"] == len("before ")
+
+    def test_clip_range_t_attribute(self):
+        text = '<clip mention="action" t="10 20"/>'
+        segs = parse_text(text, expects="clip")
+        assert len(segs) == 1
+        assert segs[0]["kind"] == "clip"
+        assert segs[0]["value"] == Clip(
+            timestamp=ClipTimestamp(at=10.0, until=20.0), mention="action"
+        )
+
+    def test_clip_mode_ignores_point_tags(self):
+        """Clip mode does not scan geometry tags — they remain in the surrounding text segment."""
+        text = '<point>(1,2)</point> and <clip t=1.0/>'
+        segs = parse_text(text, expects="clip")
+        kinds = [s["kind"] for s in segs]
+        assert kinds == ["text", "clip"]
+        assert "<point>" in segs[0]["text"]
+
+    def test_clip_inside_collection_is_found_in_clip_mode(self):
+        """expects='clip' scans the whole text — nesting under <collection> doesn't hide the clip."""
+        text = '<collection mention="bundle"><point>(1,2)</point><clip t=1.0/></collection>'
+        segs = parse_text(text, expects="clip")
+        clip_segs = [s for s in segs if s["kind"] == "clip"]
+        assert len(clip_segs) == 1
+        assert clip_segs[0]["value"].timestamp == ClipTimestamp(at=1.0)
+
+    def test_clip_without_t_raises_parse_error(self):
+        text = '<clip mention="bare"/>'
+        with pytest.raises(ParseError) as exc_info:
+            parse_text(text, expects="clip")
+        assert exc_info.value.code == "invalid_clip_timestamp"
+
+    def test_clip_with_unparseable_t_raises_parse_error(self):
+        text = '<clip t="not-a-number"/>'
+        with pytest.raises(ParseError) as exc_info:
+            parse_text(text, expects="clip")
+        assert exc_info.value.code == "invalid_clip_timestamp"
+
+    def test_default_expects_does_not_parse_clips(self):
+        """Default mode preserves the geometry-only contract — clip tags stay in text segments."""
+        text = 'before <clip t=1.5/> after'
+        segs = parse_text(text)
+        assert len(segs) == 1
+        assert segs[0]["kind"] == "text"
+        assert "<clip" in segs[0]["text"]


### PR DESCRIPTION
## Summary

  `parse_text()` was blind to `<clip />` tags — it only matched `point|point_box|polygon|collection` (`_FULL_TAG`), so when a clip-mode response came back, the entire text (including all clip tags) collapsed into a single `kind: "text"` segment. Result: `result.parsed` was unusable for `expects="clip"` callers; only `result.clips` (via the separate
  `extract_clips()` path) worked.

  The streaming events path at `client.py:_point_events` also depended on `parse_text` returning clip-kind segments to emit `points.delta` events for clips — those events never fired.

  ## Approach

  Rather than merging shape and clip regexes into one walker (which re-introduces overlap/nesting edge cases), gate `parse_text` on `expects`:

  - `expects="clip"` → scan `_CLIP_TAG` only, emit `kind: "clip"` segments
  - `expects in {"point","box","polygon"}` or `None` → scan `_FULL_TAG` only (original behavior, untouched)
  - anything else → return input as a single text segment

  The caller already knows what it expects (it's the key into `_BUCKET_BY_EXPECTS`), so threading it three lines down into `parse_text` is essentially free.

  ## Changes

  **`src/perceptron/pointing/parser.py`**
  - `parse_text(text, *, expects=None)` — new keyword arg dispatches between shape and clip scanning. Default `None` preserves the original geometry-only contract (backwards-compatible for any caller that didn't pass `expects`).
  - New `_scan_segments(text, pattern, handler)` helper holds the shared walker logic (text-fill on gaps, segment per match, trailing text). Two thin handlers (`_shape_match_to_segment`, `_clip_match_to_segment`) encode only the per-match parse.
  - New `_parse_clip_body(attrs)` returns a `Clip` and raises `ParseError(code="invalid_clip_timestamp")` when `t=` is missing or unparseable — symmetric with `_parse_point_body` / `_parse_box_body` / `_parse_polygon_body`.
  - Tightened the `obj` annotation in the shape handler from `Any` to `SinglePoint | BoundingBox | Polygon | Collection`.

  **`src/perceptron/client.py`**
  - Three `parse_text(content)` call sites (final result builders + streaming `_point_events`) now pass `expects=expects`.

  **`tests/test_pointing_parser.py`** — new `TestParseTextClipSegments` class (7 tests):
  - Top-level clip emits `kind: "clip"` segment with the right `Clip` value and span
  - Range `t="10 20"` produces `ClipTimestamp(at=10, until=20)`
  - Clip mode ignores `<point>` tags (they remain in the text segment)
  - Clip nested inside `<collection>` is found in clip mode (improvement over the geometry-only path)
  - Missing/unparseable `t=` raises `ParseError(code="invalid_clip_timestamp")` (2 cases)
  - Default mode (`expects=None`) still treats `<clip>` as plain text — backwards-compatibility guard

  `extract_clips()` is unchanged: still lenient (drops malformed clips silently per `test_extract_clip_skips_missing_timestamp`). Strict-vs-lenient is split deliberately by entry point.