### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "perceptron"
-version = "0.3.3"
+version = "0.3.4"
 description = "Perceptron multimodal SDK"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/perceptron/__init__.py
+++ b/src/perceptron/__init__.py
@@ -13,7 +13,7 @@ network access. Transport and streaming are added in later phases.
 
 import importlib
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 from .annotations import annotate_image
 from .client import (


### PR DESCRIPTION
## Summary
Bump SDK version from 0.3.3 to 0.3.4 in `pyproject.toml` and `src/perceptron/__init__.py`.

Follows the pattern of #69 (0.3.1) and #62 (0.3.0). The cookbook README's "v0.3.4+ SDK API" string (#76) now lines up with the package version.