### PR TITLE
fix: avoid shape mismatch for empty dims in mrope tensor

### DIFF
--- a/src/perceptron/tensorstream/ops.py
+++ b/src/perceptron/tensorstream/ops.py
@@ -35,7 +35,8 @@ def compute_mrope_pos_tensor(ts: TensorStream, n_pos_dims: int = 3) -> torch.Ten
 
         for event in stream:
             # --- build coordinate grid for THIS event using itertools (no tensor ops) ---
-            dims = (event.dims() or [1]) + [1] * (n_pos_dims - len(event.dims() or []))
+            raw_dims = event.dims() or [1]
+            dims = raw_dims + [1] * (n_pos_dims - len(raw_dims))
 
             # Create ranges for each dimension (similar to old _finalize implementation)
             first_dim = range(cumulative_offset, cumulative_offset + dims[0])

--- a/tests/test_tensorstream_utils.py
+++ b/tests/test_tensorstream_utils.py
@@ -1,0 +1,22 @@
+import torch
+
+from perceptron.tensorstream.tensorstream import Event, Stream, TensorStream, TextType
+from perceptron.tensorstream.ops import compute_mrope_pos_tensor
+
+
+def test_compute_mrope_pos_tensor_empty_dims_no_shape_mismatch():
+    # event.dims() == [] previously produced n_pos_dims + 1 entries
+    # due to inconsistent fallback handling across repeated calls.
+    event = Event(
+        data=torch.zeros(1, dtype=torch.long),
+        time=(0.0, 1.0),
+        type=TextType.text,
+        dims_virtual=[],
+        idx_range=(0, 1),
+    )
+    stream = Stream(events=[event], priority=[TextType.text])
+    ts = TensorStream(streams=[stream])
+
+    result = compute_mrope_pos_tensor(ts, n_pos_dims=3)
+
+    assert result.shape == (1, 1, 3)


### PR DESCRIPTION
event.dims() was called twice in one expression with inconsistent fallback, when it returned [], dims ended up one element too long and the final reshape would fail or silently produce wrong coordinates.

Fixed by evaluating event.dims() once and reusing the result. Adds a regression test for this case.